### PR TITLE
Add a maven central badge latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 JHipster server-side library
 ----------------------------
 
-[![Build Status][travis-image]][travis-url]
+[![Build Status][travis-image]][travis-url] [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.github.jhipster/jhipster/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.github.jhipster/jhipster)
 
 This project is used by the JHipster generator, for more information, issues or questions, please go to [jhipster/generator-jhipster](https://github.com/jhipster/generator-jhipster).
 


### PR DESCRIPTION
![screen shot 2017-01-25 at 14 10 14](https://cloud.githubusercontent.com/assets/513471/22291707/05ff55ea-e308-11e6-8f70-d2550f75e0a9.png)