### PR TITLE
Upgrade to support Ehcache programmatic configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
 
         <!-- Library properties -->
-        <hibernate.version>5.2.4.Final</hibernate.version>
+        <hibernate.version>5.2.8.Final</hibernate.version>
         <liquibase-slf4j.version>2.0.0</liquibase-slf4j.version>
         <liquibase-hibernate5.version>3.6</liquibase-hibernate5.version>
         <prometheus-simpleclient.version>0.0.20</prometheus-simpleclient.version>

--- a/src/main/java/io/github/jhipster/config/JHipsterProperties.java
+++ b/src/main/java/io/github/jhipster/config/JHipsterProperties.java
@@ -178,8 +178,14 @@ public class JHipsterProperties {
 
         private final Hazelcast hazelcast = new Hazelcast();
 
+        private final Ehcache ehcache = new Ehcache();
+
         public Hazelcast getHazelcast() {
             return hazelcast;
+        }
+
+        public Ehcache getEhcache() {
+            return ehcache;
         }
 
         public static class Hazelcast {
@@ -202,6 +208,29 @@ public class JHipsterProperties {
 
             public void setBackupCount(int backupCount) {
                 this.backupCount = backupCount;
+            }
+        }
+
+        public static class Ehcache {
+
+            private int timeToLiveSeconds = 3600;
+
+            private long maxEntries = 100;
+
+            public int getTimeToLiveSeconds() {
+                return timeToLiveSeconds;
+            }
+
+            public void setTimeToLiveSeconds(int timeToLiveSeconds) {
+                this.timeToLiveSeconds = timeToLiveSeconds;
+            }
+
+            public long getMaxEntries() {
+                return maxEntries;
+            }
+
+            public void setMaxEntries(long maxEntries) {
+                this.maxEntries = maxEntries;
             }
         }
     }

--- a/src/main/java/io/github/jhipster/config/jcache/NoDefaultJCacheRegionFactory.java
+++ b/src/main/java/io/github/jhipster/config/jcache/NoDefaultJCacheRegionFactory.java
@@ -22,25 +22,20 @@ import java.util.Properties;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.jcache.JCacheRegionFactory;
+import org.hibernate.cache.spi.CacheDataDescription;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 
+import javax.cache.Cache;
+
 /**
- * Special Hibernate region factory that will convert a Spring URI (e.g. classpath:ehcache.xml) to a real URI (e.g.
- * file://ehcache.xml).
+ * Extends the default {@code JCacheRegionFactory} but makes sure all caches are already existing to prevent
+ * spontaneous creation of badly configured caches (e.g. {@code new MutableConfiguration()}.
  */
-public class SpringCacheRegionFactory extends JCacheRegionFactory {
+public class NoDefaultJCacheRegionFactory extends JCacheRegionFactory {
 
     @Override
-    public void start(SessionFactoryOptions options, Properties properties) throws CacheException {
-        // Translate the Spring URI to a real URI
-        String uri = properties.getProperty(CONFIG_URI);
-        Resource resource = new DefaultResourceLoader().getResource(uri);
-        try {
-            properties.setProperty(CONFIG_URI, resource.getURI().toString());
-        } catch (IOException e) {
-            throw new CacheException(e);
-        }
-        super.start(options, properties);
+    protected Cache<Object, Object> createCache(String regionName, Properties properties, CacheDataDescription metadata) {
+        throw new IllegalStateException("All Hibernate caches should be created upfront. Please update CacheConfiguration.java with the missing cache");
     }
 }

--- a/src/main/java/io/github/jhipster/web/util/ResponseUtil.java
+++ b/src/main/java/io/github/jhipster/web/util/ResponseUtil.java
@@ -31,6 +31,10 @@ public final class ResponseUtil {
     /**
      * Wrap the optional into a {@link ResponseEntity} with an {@link HttpStatus#OK} status, or if it's empty,
      * it returns a {@link ResponseEntity} with {@link HttpStatus#NOT_FOUND}.
+     *
+     * @param <X> type of the response
+     * @param maybeResponse response to return if present
+     * @return response containing {@code maybeResponse} if present or {@link HttpStatus#NOT_FOUND}
      */
     public static <X> ResponseEntity<X> wrapOrNotFound(Optional<X> maybeResponse) {
         return wrapOrNotFound(maybeResponse, null);
@@ -39,6 +43,11 @@ public final class ResponseUtil {
     /**
      * Wrap the optional into a {@link ResponseEntity} with an {@link HttpStatus#OK} status with the headers,
      * or if it's empty, it returns a {@link ResponseEntity} with {@link HttpStatus#NOT_FOUND}.
+     *
+     * @param <X> type of the response
+     * @param maybeResponse response to return if present
+     * @param header headers to be added to the response
+     * @return response containing {@code maybeResponse} if present or {@link HttpStatus#NOT_FOUND}
      */
     public static <X> ResponseEntity<X> wrapOrNotFound(Optional<X> maybeResponse, HttpHeaders header) {
         return maybeResponse.map(response -> ResponseEntity.ok().headers(header).body(response))


### PR DESCRIPTION
Some notes:
* Used by jhipster/generator-jhipster#5286
* The `SpringCacheRegionFactory` was removed. I don't need it anymore. However, it is still required for someone to use `ehcache.xml`. So maybe it should stay
* Hibernate was upgrade to include a really useful be patch [HHH-11471](https://hibernate.atlassian.net/browse/HHH-11471)
* The NoDefaultJCacheRegionFactory is not mandatory but makes the cache creations much safer
