### PR TITLE
Consistent log messages for AsyncSpringLiquibase

### DIFF
--- a/src/main/java/io/github/jhipster/config/liquibase/AsyncSpringLiquibase.java
+++ b/src/main/java/io/github/jhipster/config/liquibase/AsyncSpringLiquibase.java
@@ -57,19 +57,18 @@ public class AsyncSpringLiquibase extends SpringLiquibase {
                 .SPRING_PROFILE_HEROKU)) {
                 taskExecutor.execute(() -> {
                     try {
-                        logger.warn("Starting Liquibase asynchronously, your database might not be ready at startup!");
+                        logger.warn("Scheduling background DB setup via Liquibase; the database will not be ready until DB setup finishes");
                         initDb();
                     } catch (LiquibaseException e) {
-                        logger.error("Liquibase could not start correctly, your database is NOT ready: {}", e
-                            .getMessage(), e);
+                        logger.error("Error scheduling DB setup via Liquibase; the database will not become ready, reason:", e);
                     }
                 });
             } else {
-                logger.debug("Starting Liquibase synchronously");
+                logger.debug("Starting DB setup via Liquibase");
                 initDb();
             }
         } else {
-            logger.debug("Liquibase is disabled");
+            logger.debug("DB setup via Liquibase is disabled");
         }
     }
 
@@ -78,6 +77,6 @@ public class AsyncSpringLiquibase extends SpringLiquibase {
         watch.start();
         super.afterPropertiesSet();
         watch.stop();
-        logger.debug("Started Liquibase in {} ms", watch.getTotalTimeMillis());
+        logger.debug("DB setup via Liquibase finished in {} ms", watch.getTotalTimeMillis());
     }
 }


### PR DESCRIPTION
"Starting liquibase" without an associated "stopping liquibase" message made me think that Liquibase is kept running, which does not make sense and indeed is not what's happening.
I took the liberty of giving the process the "DB setup via Liquibase" name, and use that consistently in log messages so readers can associate the message with a process without having to look at the (possibly abbreviated) class name.

I also removed the `e.getMessage()` call:
* by default, the exception message will be printed by logger.error(..., e) anyway so it's just going to be noise;
* if an installation is configured to not show exception messages, `AsyncSpringLiquibase` shouldn't subvert that decision IMHO. E.g. logback's default formatter allows "suppress all exception info", "show just the exception message", and "show message and full call stack".