### PR TITLE
add marker "metrics" to SpectatorLogMetricWriter logs

### DIFF
--- a/src/main/java/io/github/jhipster/config/metrics/SpectatorLogMetricWriter.java
+++ b/src/main/java/io/github/jhipster/config/metrics/SpectatorLogMetricWriter.java
@@ -21,6 +21,7 @@ package io.github.jhipster.config.metrics;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MarkerFactory;
 import org.springframework.boot.actuate.metrics.Metric;
 import org.springframework.boot.actuate.metrics.writer.Delta;
 import org.springframework.boot.actuate.metrics.writer.MetricWriter;
@@ -65,13 +66,13 @@ public class SpectatorLogMetricWriter implements MetricWriter {
             }
         }
 
-        log.info("type=GAUGE, hystrix_type={}, service={}, method={}, name={}, value={}", hystrixType, serviceName,
+        log.info(MarkerFactory.getMarker("metrics"),"type=GAUGE, hystrix_type={}, service={}, method={}, name={}, value={}", hystrixType, serviceName,
             methodName, metricName, metric.getValue());
     }
 
     @Override
     public void increment(Delta<?> metric) {
-        log.info("type=COUNTER, name={}, count={}", metric.getName(), metric.getValue());
+        log.info(MarkerFactory.getMarker("metrics"),"type=COUNTER, name={}, count={}", metric.getName(), metric.getValue());
     }
 
     @Override


### PR DESCRIPTION
This is needed so that spectator metrics are only sent to logstash and not printed to console or file appenders, see: https://github.com/jhipster/generator-jhipster/pull/6213