### PR TITLE
Improve the criteria API

### DIFF
--- a/src/main/java/io/github/jhipster/service/QueryService.java
+++ b/src/main/java/io/github/jhipster/service/QueryService.java
@@ -141,6 +141,8 @@ public abstract class QueryService<ENTITY> {
         SingularAttribute<OTHER, X> valueField) {
         if (filter.getEquals() != null) {
             return equalsSpecification(reference, valueField, filter.getEquals());
+        } else if (filter.getIn() != null) {
+            return valueIn(reference, valueField, filter.getIn());
         } else if (filter.getSpecified() != null) {
             return byFieldSpecified(reference, filter.getSpecified());
         }
@@ -212,6 +214,17 @@ public abstract class QueryService<ENTITY> {
         values) {
         return (root, query, builder) -> {
             In<X> in = builder.in(root.get(field));
+            for (X value : values) {
+                in = in.value(value);
+            }
+            return in;
+        };
+    }
+
+    protected <OTHER, X> Specification<ENTITY> valueIn(SingularAttribute<? super ENTITY, OTHER> reference,
+            SingularAttribute<OTHER, X> valueField, final Collection<X> values) {
+        return (root, query, builder) -> {
+            In<X> in = builder.in(root.get(reference).get(valueField));
             for (X value : values) {
                 in = in.value(value);
             }

--- a/src/main/java/io/github/jhipster/service/filter/Filter.java
+++ b/src/main/java/io/github/jhipster/service/filter/Filter.java
@@ -41,24 +41,27 @@ public class Filter<FIELD_TYPE> {
         return equals;
     }
 
-    public void setEquals(FIELD_TYPE equals) {
+    public Filter<FIELD_TYPE> setEquals(FIELD_TYPE equals) {
         this.equals = equals;
+        return this;
     }
 
     public Boolean getSpecified() {
         return specified;
     }
 
-    public void setSpecified(Boolean specified) {
+    public Filter<FIELD_TYPE> setSpecified(Boolean specified) {
         this.specified = specified;
+        return this;
     }
 
     public List<FIELD_TYPE> getIn() {
         return in;
     }
 
-    public void setIn(List<FIELD_TYPE> in) {
+    public Filter<FIELD_TYPE> setIn(List<FIELD_TYPE> in) {
         this.in = in;
+        return this;
     }
 
     @Override

--- a/src/main/java/io/github/jhipster/service/filter/InstantFilter.java
+++ b/src/main/java/io/github/jhipster/service/filter/InstantFilter.java
@@ -33,32 +33,37 @@ public class InstantFilter extends RangeFilter<Instant> {
 
     @Override
     @DateTimeFormat(iso = ISO.DATE_TIME)
-    public void setEquals(Instant equals) {
+    public InstantFilter setEquals(Instant equals) {
         super.setEquals(equals);
+        return this;
     }
 
     @Override
     @DateTimeFormat(iso = ISO.DATE_TIME)
-    public void setGreaterThan(Instant equals) {
+    public InstantFilter setGreaterThan(Instant equals) {
         super.setGreaterThan(equals);
+        return this;
     }
 
     @Override
     @DateTimeFormat(iso = ISO.DATE_TIME)
-    public void setGreaterOrEqualThan(Instant equals) {
+    public InstantFilter setGreaterOrEqualThan(Instant equals) {
         super.setGreaterOrEqualThan(equals);
+        return this;
     }
 
     @Override
     @DateTimeFormat(iso = ISO.DATE_TIME)
-    public void setLessThan(Instant equals) {
+    public InstantFilter setLessThan(Instant equals) {
         super.setLessThan(equals);
+        return this;
     }
 
     @Override
     @DateTimeFormat(iso = ISO.DATE_TIME)
-    public void setLessOrEqualThan(Instant equals) {
+    public InstantFilter setLessOrEqualThan(Instant equals) {
         super.setLessOrEqualThan(equals);
+        return this;
     }
 
 }

--- a/src/main/java/io/github/jhipster/service/filter/LocalDateFilter.java
+++ b/src/main/java/io/github/jhipster/service/filter/LocalDateFilter.java
@@ -34,38 +34,44 @@ public class LocalDateFilter extends RangeFilter<LocalDate> {
 
     @Override
     @DateTimeFormat(iso = ISO.DATE)
-    public void setEquals(LocalDate equals) {
+    public LocalDateFilter setEquals(LocalDate equals) {
         super.setEquals(equals);
+        return this;
     }
 
     @Override
     @DateTimeFormat(iso = ISO.DATE)
-    public void setGreaterThan(LocalDate equals) {
+    public LocalDateFilter setGreaterThan(LocalDate equals) {
         super.setGreaterThan(equals);
+        return this;
     }
 
     @Override
     @DateTimeFormat(iso = ISO.DATE)
-    public void setGreaterOrEqualThan(LocalDate equals) {
+    public LocalDateFilter setGreaterOrEqualThan(LocalDate equals) {
         super.setGreaterOrEqualThan(equals);
+        return this;
     }
 
     @Override
     @DateTimeFormat(iso = ISO.DATE)
-    public void setLessThan(LocalDate equals) {
+    public LocalDateFilter setLessThan(LocalDate equals) {
         super.setLessThan(equals);
+        return this;
     }
 
     @Override
     @DateTimeFormat(iso = ISO.DATE)
-    public void setLessOrEqualThan(LocalDate equals) {
+    public LocalDateFilter setLessOrEqualThan(LocalDate equals) {
         super.setLessOrEqualThan(equals);
+        return this;
     }
 
     @Override
     @DateTimeFormat(iso = ISO.DATE)
-    public void setIn(List<LocalDate> in) {
+    public LocalDateFilter setIn(List<LocalDate> in) {
         super.setIn(in);
+        return this;
     }
 
 }

--- a/src/main/java/io/github/jhipster/service/filter/RangeFilter.java
+++ b/src/main/java/io/github/jhipster/service/filter/RangeFilter.java
@@ -54,32 +54,36 @@ public class RangeFilter<FIELD_TYPE extends Comparable<? super FIELD_TYPE>> exte
         return greaterThan;
     }
 
-    public void setGreaterThan(FIELD_TYPE greaterThan) {
+    public RangeFilter<FIELD_TYPE> setGreaterThan(FIELD_TYPE greaterThan) {
         this.greaterThan = greaterThan;
+        return this;
     }
 
     public FIELD_TYPE getGreaterOrEqualThan() {
         return greaterOrEqualThan;
     }
 
-    public void setGreaterOrEqualThan(FIELD_TYPE greaterOrEqualThan) {
+    public RangeFilter<FIELD_TYPE> setGreaterOrEqualThan(FIELD_TYPE greaterOrEqualThan) {
         this.greaterOrEqualThan = greaterOrEqualThan;
+        return this;
     }
 
     public FIELD_TYPE getLessThan() {
         return lessThan;
     }
 
-    public void setLessThan(FIELD_TYPE lessThan) {
+    public RangeFilter<FIELD_TYPE> setLessThan(FIELD_TYPE lessThan) {
         this.lessThan = lessThan;
+        return this;
     }
 
     public FIELD_TYPE getLessOrEqualThan() {
         return lessOrEqualThan;
     }
 
-    public void setLessOrEqualThan(FIELD_TYPE lessOrEqualThan) {
+    public RangeFilter<FIELD_TYPE> setLessOrEqualThan(FIELD_TYPE lessOrEqualThan) {
         this.lessOrEqualThan = lessOrEqualThan;
+        return this;
     }
 
     @Override

--- a/src/main/java/io/github/jhipster/service/filter/StringFilter.java
+++ b/src/main/java/io/github/jhipster/service/filter/StringFilter.java
@@ -38,8 +38,9 @@ public class StringFilter extends Filter<String> {
         return contains;
     }
 
-    public void setContains(String contains) {
+    public StringFilter setContains(String contains) {
         this.contains = contains;
+        return this;
     }
 
     @Override

--- a/src/main/java/io/github/jhipster/service/filter/ZonedDateTimeFilter.java
+++ b/src/main/java/io/github/jhipster/service/filter/ZonedDateTimeFilter.java
@@ -34,37 +34,43 @@ public class ZonedDateTimeFilter extends RangeFilter<ZonedDateTime> {
 
     @Override
     @DateTimeFormat(iso = ISO.DATE_TIME)
-    public void setEquals(ZonedDateTime equals) {
+    public ZonedDateTimeFilter setEquals(ZonedDateTime equals) {
         super.setEquals(equals);
+        return this;
     }
 
     @Override
     @DateTimeFormat(iso = ISO.DATE_TIME)
-    public void setGreaterThan(ZonedDateTime equals) {
+    public ZonedDateTimeFilter setGreaterThan(ZonedDateTime equals) {
         super.setGreaterThan(equals);
+        return this;
     }
 
     @Override
     @DateTimeFormat(iso = ISO.DATE_TIME)
-    public void setGreaterOrEqualThan(ZonedDateTime equals) {
+    public ZonedDateTimeFilter setGreaterOrEqualThan(ZonedDateTime equals) {
         super.setGreaterOrEqualThan(equals);
+        return this;
     }
 
     @Override
     @DateTimeFormat(iso = ISO.DATE_TIME)
-    public void setLessThan(ZonedDateTime equals) {
+    public ZonedDateTimeFilter setLessThan(ZonedDateTime equals) {
         super.setLessThan(equals);
+        return this;
     }
 
     @Override
     @DateTimeFormat(iso = ISO.DATE_TIME)
-    public void setLessOrEqualThan(ZonedDateTime equals) {
+    public ZonedDateTimeFilter setLessOrEqualThan(ZonedDateTime equals) {
         super.setLessOrEqualThan(equals);
+        return this;
     }
 
     @Override
     @DateTimeFormat(iso = ISO.DATE_TIME)
-    public void setIn(List<ZonedDateTime> in) {
+    public ZonedDateTimeFilter setIn(List<ZonedDateTime> in) {
         super.setIn(in);
+        return this;
     }
 }


### PR DESCRIPTION
Setter should return the criteria, so it can be used more concisely : 
Instead of this:
```
BankCriteria bc = new BankCriteria();
bc.setAccountHolderName(new StringFilter());
bc.getAccountHolderName().setContains("john");
```
One can write:
```
BankCriteria bc = new BankCriteria();
bc.setAccountHolderName(new StringFilter().setContains("john"));
```

And fix the missed 'in' fragment handling

