### PR TITLE
Add ZonedDateTime converter to Long and vice versa

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,18 @@
             <artifactId>spring-boot-starter-cloud-connectors</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <distributionManagement>
         <snapshotRepository>
@@ -327,10 +339,18 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.20.1</version>
                 <configuration>
                     <!-- Force alphabetical order to have a reproducible build -->
                     <runOrder>alphabetical</runOrder>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>2.20.1</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/src/main/java/io/github/jhipster/domain/util/JSR310DateConverters.java
+++ b/src/main/java/io/github/jhipster/domain/util/JSR310DateConverters.java
@@ -82,25 +82,25 @@ public final class JSR310DateConverters {
         }
     }
 
-    public static class StringToZonedDateTimeConverter implements Converter<String, ZonedDateTime> {
-        public static final StringToZonedDateTimeConverter INSTANCE = new StringToZonedDateTimeConverter();
+    public static class LongToZonedDateTimeConverter implements Converter<Long, ZonedDateTime> {
+        public static final LongToZonedDateTimeConverter INSTANCE = new LongToZonedDateTimeConverter();
 
-        private StringToZonedDateTimeConverter() {
+        private LongToZonedDateTimeConverter() {
         }
 
-        public ZonedDateTime convert(String source) {
-            return source == null ? null : ZonedDateTime.parse(source);
+        public ZonedDateTime convert(Long source) {
+            return source == null ? null : ZonedDateTime.ofInstant(Instant.ofEpochMilli(source), ZoneOffset.UTC);
         }
     }
 
-    public static class ZonedDateTimeToStringConverter implements Converter<ZonedDateTime, String> {
-        public static final ZonedDateTimeToStringConverter INSTANCE = new ZonedDateTimeToStringConverter();
+    public static class ZonedDateTimeToLongConverter implements Converter<ZonedDateTime, Long> {
+        public static final ZonedDateTimeToLongConverter INSTANCE = new ZonedDateTimeToLongConverter();
 
-        private ZonedDateTimeToStringConverter() {
+        private ZonedDateTimeToLongConverter() {
         }
 
-        public String convert(ZonedDateTime source) {
-            return source == null ? null : source.toString();
+        public Long convert(ZonedDateTime source) {
+            return source == null ? null : source.toInstant().toEpochMilli();
         }
     }
 

--- a/src/main/java/io/github/jhipster/domain/util/JSR310DateConverters.java
+++ b/src/main/java/io/github/jhipster/domain/util/JSR310DateConverters.java
@@ -82,6 +82,28 @@ public final class JSR310DateConverters {
         }
     }
 
+    public static class StringToZonedDateTimeConverter implements Converter<String, ZonedDateTime> {
+        public static final StringToZonedDateTimeConverter INSTANCE = new StringToZonedDateTimeConverter();
+
+        private StringToZonedDateTimeConverter() {
+        }
+
+        public ZonedDateTime convert(String source) {
+            return source == null ? null : ZonedDateTime.parse(source);
+        }
+    }
+
+    public static class ZonedDateTimeToStringConverter implements Converter<ZonedDateTime, String> {
+        public static final ZonedDateTimeToStringConverter INSTANCE = new ZonedDateTimeToStringConverter();
+
+        private ZonedDateTimeToStringConverter() {
+        }
+
+        public String convert(ZonedDateTime source) {
+            return source == null ? null : source.toString();
+        }
+    }
+
     public static class LocalDateTimeToDateConverter implements Converter<LocalDateTime, Date> {
 
         public static final LocalDateTimeToDateConverter INSTANCE = new LocalDateTimeToDateConverter();

--- a/src/test/java/io/github/jhipster/domain/util/JSR310DateConvertersTest.java
+++ b/src/test/java/io/github/jhipster/domain/util/JSR310DateConvertersTest.java
@@ -1,0 +1,36 @@
+package io.github.jhipster.domain.util;
+
+import org.junit.Test;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class JSR310DateConvertersTest {
+
+    @Test
+    public void testThatLongIsConvertedToZonedDateTimeProperly() {
+        JSR310DateConverters.LongToZonedDateTimeConverter longToZonedDateTimeConverter = JSR310DateConverters.LongToZonedDateTimeConverter.INSTANCE;
+
+        ZonedDateTime expectedResult = ZonedDateTime.now(ZoneOffset.UTC);
+
+        ZonedDateTime result = longToZonedDateTimeConverter.convert(expectedResult.toInstant().toEpochMilli());
+
+        assertThat(result, equalTo(expectedResult));
+    }
+
+    @Test
+    public void testThatZonedDateTimeIsConvertedToLongProperly() {
+        JSR310DateConverters.ZonedDateTimeToLongConverter zonedDateTimeToLongConverter = JSR310DateConverters.ZonedDateTimeToLongConverter.INSTANCE;
+
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+
+        long expectedResult = now.toInstant().toEpochMilli();
+
+        long result = zonedDateTimeToLongConverter.convert(now);
+
+        assertThat(result, equalTo(expectedResult));
+    }
+}


### PR DESCRIPTION
The goal of the PR is to use String instead of Date because the ZonedDateTime create from the database is slightly different than the original one causing some tests to fail when using Jhipster with mongo and elasticsearch. https://github.com/jhipster/generator-jhipster/pull/6595