### PR TITLE
Build specification for referring entities field with a join

### DIFF
--- a/src/main/java/io/github/jhipster/service/QueryService.java
+++ b/src/main/java/io/github/jhipster/service/QueryService.java
@@ -21,6 +21,7 @@ package io.github.jhipster.service;
 
 import java.util.Collection;
 import javax.persistence.criteria.CriteriaBuilder.In;
+import javax.persistence.criteria.JoinType;
 import javax.persistence.metamodel.SetAttribute;
 import javax.persistence.metamodel.SingularAttribute;
 
@@ -144,7 +145,7 @@ public abstract class QueryService<ENTITY> {
         } else if (filter.getIn() != null) {
             return valueIn(reference, valueField, filter.getIn());
         } else if (filter.getSpecified() != null) {
-            return byFieldSpecified(reference, filter.getSpecified());
+            return byReferringEntitiesFieldSpecified(reference, filter.getSpecified());
         }
         return null;
     }
@@ -197,6 +198,12 @@ public abstract class QueryService<ENTITY> {
     protected Specification<ENTITY> likeUpperSpecification(SingularAttribute<? super ENTITY, String> field, final
     String value) {
         return (root, query, builder) -> builder.like(builder.upper(root.get(field)), wrapLikeQuery(value));
+    }
+
+    protected <X> Specification<ENTITY> byReferringEntitiesFieldSpecified(SingularAttribute<? super ENTITY, X> field, final boolean
+        specified) {
+        return specified ? (root, query, builder) -> builder.isNotNull(root.join(field, JoinType.LEFT)) : (root, query, builder) ->
+            builder.isNull(root.join(field, JoinType.LEFT));
     }
 
     protected <X> Specification<ENTITY> byFieldSpecified(SingularAttribute<? super ENTITY, X> field, final boolean


### PR DESCRIPTION
After the discussion on generator-jhipster issue [6735](https://github.com/jhipster/generator-jhipster/issues/6735) I agree with the proposal from @ctamisier. For that case I add a new method in the QueryService. It will be good if we can cover this new method over a test.
[This ](https://github.com/spring-projects/spring-data-jpa/blob/master/src/test/java/org/springframework/data/jpa/repository/query/SimpleJpaQueryUnitTests.java)Spring Data JPA test looks like a good inspiration  but I did not manage at the moment more than the manual tests 😞 . Nonetheless, this method works for filtering entities in a one-to-one relationship when the referenced filed is part of the owning part.


Fixes #6735