### PR TITLE
Info management endpoint improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-ribbon</artifactId>
+            <artifactId>spring-cloud-starter-netflix-ribbon</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/src/main/java/io/github/jhipster/config/JHipsterProperties.java
+++ b/src/main/java/io/github/jhipster/config/JHipsterProperties.java
@@ -24,14 +24,22 @@ import java.util.Map;
 import javax.validation.constraints.NotNull;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
 import org.springframework.web.cors.CorsConfiguration;
 
 /**
  * Properties specific to JHipster.
  *
  * <p> Properties are configured in the application.yml file. </p>
+ * <p> This class also load properties in the Spring Environment from the git.properties and META-INF/build-info.properties
+ * files if they are found in the classpath.</p>
  */
 @ConfigurationProperties(prefix = "jhipster", ignoreUnknownFields = false)
+@PropertySources({
+    @PropertySource(value = "classpath:git.properties", ignoreResourceNotFound = true),
+    @PropertySource(value = "classpath:META-INF/build-info.properties", ignoreResourceNotFound = true)
+})
 public class JHipsterProperties {
 
     private final Async async = new Async();

--- a/src/main/java/io/github/jhipster/config/JHipsterProperties.java
+++ b/src/main/java/io/github/jhipster/config/JHipsterProperties.java
@@ -56,8 +56,6 @@ public class JHipsterProperties {
 
     private final Gateway gateway = new Gateway();
 
-    private final Ribbon ribbon = new Ribbon();
-
     private final Registry registry = new Registry();
 
     public Async getAsync() {
@@ -106,10 +104,6 @@ public class JHipsterProperties {
 
     public Gateway getGateway() {
         return gateway;
-    }
-
-    public Ribbon getRibbon() {
-        return ribbon;
     }
 
     public static class Async {
@@ -845,19 +839,6 @@ public class JHipsterProperties {
             public void setDurationInSeconds(int durationInSeconds) {
                 this.durationInSeconds = durationInSeconds;
             }
-        }
-    }
-
-    public static class Ribbon {
-
-        private String[] displayOnActiveProfiles = JHipsterDefaults.Ribbon.displayOnActiveProfiles;
-
-        public String[] getDisplayOnActiveProfiles() {
-            return displayOnActiveProfiles;
-        }
-
-        public void setDisplayOnActiveProfiles(String[] displayOnActiveProfiles) {
-            this.displayOnActiveProfiles = displayOnActiveProfiles;
         }
     }
 

--- a/src/main/java/io/github/jhipster/config/apidoc/SwaggerConfiguration.java
+++ b/src/main/java/io/github/jhipster/config/apidoc/SwaggerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors from the JHipster project.
+ * Copyright 2016-2018 the original author or authors from the JHipster project.
  *
  * This file is part of the JHipster project, see http://www.jhipster.tech/
  * for more information.
@@ -122,8 +122,7 @@ public class SwaggerConfiguration {
     @Bean
     public Docket swaggerSpringfoxManagementDocket(@Value("${spring.application.name}") String appName,
         @Value("${management.endpoints.web.base-path}") String managementContextPath,
-        @Value("${info.project.version}") String appVersion) {
-
+        @Value("${build.version:}") String appVersion) {
         return createDocket()
             .apiInfo(new ApiInfo(appName + " " + MANAGEMENT_TITLE_SUFFIX, MANAGEMENT_DESCRIPTION,
                 appVersion, "", ApiInfo.DEFAULT_CONTACT, "", "", new ArrayList<>()))

--- a/src/main/java/io/github/jhipster/config/info/ActiveProfilesInfoContributor.java
+++ b/src/main/java/io/github/jhipster/config/info/ActiveProfilesInfoContributor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016-2018 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see http://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jhipster.config.info;
+
+import org.springframework.boot.actuate.info.Info;
+import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * An {@link InfoContributor} that exposes the list of active spring profiles.
+ *
+ */
+public class ActiveProfilesInfoContributor  implements InfoContributor {
+
+    private static final String ACTIVE_PROFILES = "active-profiles";
+    private final List<String> profiles;
+
+    public ActiveProfilesInfoContributor(ConfigurableEnvironment environment) {
+        this.profiles = Arrays.asList(environment.getActiveProfiles());
+    }
+
+    @Override
+    public void contribute(Info.Builder builder) {
+        builder.withDetail(ACTIVE_PROFILES, this.profiles);
+    }
+}

--- a/src/main/java/io/github/jhipster/config/info/ActiveProfilesInfoContributor.java
+++ b/src/main/java/io/github/jhipster/config/info/ActiveProfilesInfoContributor.java
@@ -32,7 +32,7 @@ import java.util.List;
  */
 public class ActiveProfilesInfoContributor  implements InfoContributor {
 
-    private static final String ACTIVE_PROFILES = "active-profiles";
+    private static final String ACTIVE_PROFILES = "activeProfiles";
     private final List<String> profiles;
 
     public ActiveProfilesInfoContributor(ConfigurableEnvironment environment) {

--- a/src/main/java/io/github/jhipster/config/info/JHipsterInfoContributorConfiguration.java
+++ b/src/main/java/io/github/jhipster/config/info/JHipsterInfoContributorConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2018 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see http://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jhipster.config.info;
+
+import org.springframework.boot.actuate.autoconfigure.info.ConditionalOnEnabledInfoContributor;
+import org.springframework.boot.actuate.autoconfigure.info.InfoContributorAutoConfiguration;
+import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+/**
+ * JHipster auto-configuration for custom {@link InfoContributor}s.
+ *
+ */
+@Configuration
+@AutoConfigureAfter(InfoContributorAutoConfiguration.class)
+public class JHipsterInfoContributorConfiguration {
+
+    @Bean
+    @ConditionalOnEnabledInfoContributor("active-profiles")
+    public ActiveProfilesInfoContributor activeProfilesInfoContributor(
+        ConfigurableEnvironment environment) {
+        return new ActiveProfilesInfoContributor(environment);
+    }
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,9 @@
+{"properties": [
+    {
+        "name": "management.info.active-profiles.enabled",
+        "type": "java.lang.Boolean",
+        "description": "Enable active-profiles info.",
+        "defaultValue": true
+    }
+]}
+

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  io.github.jhipster.config.apidoc.SwaggerConfiguration,\
   io.github.jhipster.config.JHipsterProperties,\
+  io.github.jhipster.config.apidoc.SwaggerConfiguration,\
+  io.github.jhipster.config.info.JHipsterInfoContributorConfiguration,\
   io.github.jhipster.security.uaa.UaaAutoConfiguration

--- a/src/test/java/io/github/jhipster/config/JHipsterPropertiesTest.java
+++ b/src/test/java/io/github/jhipster/config/JHipsterPropertiesTest.java
@@ -629,24 +629,6 @@ public class JHipsterPropertiesTest {
     }
 
     @Test
-    public void testRibbonDisplayOnActiveProfiles() {
-        JHipsterProperties.Ribbon obj = properties.getRibbon();
-        String[] def = JHipsterDefaults.Ribbon.displayOnActiveProfiles;
-        ArrayList<String> val;
-        if (def != null) {
-            val = newArrayList(def);
-            assertThat(obj.getDisplayOnActiveProfiles()).containsExactlyElementsOf(newArrayList(val));
-        } else {
-            assertThat(obj.getDisplayOnActiveProfiles()).isNull();
-            def = new String[1];
-            val = new ArrayList<>(1);
-        }
-        val.add("1");
-        obj.setDisplayOnActiveProfiles(val.toArray(def));
-        assertThat(obj.getDisplayOnActiveProfiles()).containsExactlyElementsOf(newArrayList(val));
-    }
-
-    @Test
     public void testRegistryPassword() {
         JHipsterProperties.Registry obj = properties.getRegistry();
         String val = JHipsterDefaults.Registry.password;


### PR DESCRIPTION
- Add git and maven build properties to /info endpoints (if build `.properties` files are on the classpath
- Add the active profiles to /info with a custom InfoContributor