### PR TITLE
Adding undertow ordered cipher configuration

### DIFF
--- a/src/main/java/io/github/jhipster/config/JHipsterDefaults.java
+++ b/src/main/java/io/github/jhipster/config/JHipsterDefaults.java
@@ -36,7 +36,7 @@ public interface JHipsterDefaults {
 
         Version version = Version.V_1_1;
 
-        boolean useUndertowUserCipherSuitesOrder = false;
+        boolean useUndertowUserCipherSuitesOrder = true;
 
         interface Cache {
 

--- a/src/main/java/io/github/jhipster/config/JHipsterDefaults.java
+++ b/src/main/java/io/github/jhipster/config/JHipsterDefaults.java
@@ -36,6 +36,8 @@ public interface JHipsterDefaults {
 
         Version version = Version.V_1_1;
 
+        boolean useUndertowUserCipherSuitesOrder = false;
+
         interface Cache {
 
             int timeToLiveInDays = 1461; // 4 years (including leap day)

--- a/src/main/java/io/github/jhipster/config/JHipsterProperties.java
+++ b/src/main/java/io/github/jhipster/config/JHipsterProperties.java
@@ -152,6 +152,11 @@ public class JHipsterProperties {
         private final Cache cache = new Cache();
 
         /**
+         * Https has to be active with cipher suite define also
+         */
+        private boolean useUndertowUserCipherSuitesOrder = JHipsterDefaults.Http.useUndertowUserCipherSuitesOrder;
+
+        /**
          * HTTP version, must be "V_1_1" (for HTTP/1.1) or V_2_0 (for (HTTP/2)
          */
         public Version version = JHipsterDefaults.Http.version;
@@ -179,6 +184,14 @@ public class JHipsterProperties {
             public void setTimeToLiveInDays(int timeToLiveInDays) {
                 this.timeToLiveInDays = timeToLiveInDays;
             }
+        }
+
+        public boolean isUseUndertowUserCipherSuitesOrder() {
+            return useUndertowUserCipherSuitesOrder;
+        }
+
+        public void setUseUndertowUserCipherSuitesOrder(boolean useUndertowUserCipherSuitesOrder) {
+            this.useUndertowUserCipherSuitesOrder = useUndertowUserCipherSuitesOrder;
         }
     }
 

--- a/src/main/java/io/github/jhipster/security/ssl/UndertowSSLConfiguration.java
+++ b/src/main/java/io/github/jhipster/security/ssl/UndertowSSLConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016-2018 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see http://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jhipster.security.ssl;
+
+import io.github.jhipster.config.JHipsterProperties;
+import io.undertow.UndertowOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * SSL config for Undertow
+ * <p>
+ * SSL_USER_CIPHER_SUITES_ORDER : It will force the cipher suite define by the user.
+ * Allow to achieve perfect forward secrecy.
+ * Can only be activated with HTTPS and a cipher suite defined by the user (server.ssl.ciphers).
+ *
+ * @see <a href="https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices#25-use-forward-secrecy" target="_blank">More explanation on perfect forward secrecy</a>
+ */
+@Configuration
+@ConditionalOnClass({UndertowServletWebServerFactory.class})
+@ConditionalOnProperty({"server.ssl.ciphers", "server.ssl.key-store"})
+public class UndertowSSLConfiguration {
+
+    private final UndertowServletWebServerFactory factory;
+
+    private final JHipsterProperties jHipsterProperties;
+
+    private final Logger log = LoggerFactory.getLogger(UndertowSSLConfiguration.class);
+
+    public UndertowSSLConfiguration(UndertowServletWebServerFactory undertowServletWebServerFactory, JHipsterProperties jHipsterProperties) {
+        this.factory = undertowServletWebServerFactory;
+        this.jHipsterProperties = jHipsterProperties;
+
+        configuringUserCipherSuiteOrder();
+    }
+
+    private void configuringUserCipherSuiteOrder() {
+        log.info("Configuring Undertow");
+        if (jHipsterProperties.getHttp().isUseUndertowUserCipherSuitesOrder()) {
+            log.info("Setting user cipher suite order to true");
+            factory.addBuilderCustomizers(builder -> builder.setSocketOption(UndertowOptions.SSL_USER_CIPHER_SUITES_ORDER, Boolean.TRUE));
+        }
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   io.github.jhipster.config.apidoc.SwaggerConfiguration,\
   io.github.jhipster.config.JHipsterProperties,\
-  io.github.jhipster.security.uaa.UaaAutoConfiguration
+  io.github.jhipster.security.uaa.UaaAutoConfiguration,\
+  io.github.jhipster.security.ssl.UndertowSSLConfiguration

--- a/src/test/java/io/github/jhipster/config/JHipsterPropertiesTest.java
+++ b/src/test/java/io/github/jhipster/config/JHipsterPropertiesTest.java
@@ -655,4 +655,14 @@ public class JHipsterPropertiesTest {
         obj.setPassword(val);
         assertThat(obj.getPassword()).isEqualTo(val);
     }
+
+    @Test
+    public void testHttpUseUndertowUserCipherSuitesOrder(){
+        JHipsterProperties.Http obj = properties.getHttp();
+        boolean val = JHipsterDefaults.Http.useUndertowUserCipherSuitesOrder;
+        assertThat(obj.isUseUndertowUserCipherSuitesOrder()).isEqualTo(val);
+        val = !val;
+        obj.setUseUndertowUserCipherSuitesOrder(val);
+        assertThat(obj.isUseUndertowUserCipherSuitesOrder()).isEqualTo(val);
+    }
 }

--- a/src/test/java/io/github/jhipster/security/ssl/UndertowSSLConfigurationTest.java
+++ b/src/test/java/io/github/jhipster/security/ssl/UndertowSSLConfigurationTest.java
@@ -1,0 +1,57 @@
+package io.github.jhipster.security.ssl;
+
+import io.github.jhipster.config.JHipsterProperties;
+import io.undertow.Undertow;
+import io.undertow.UndertowOptions;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.xnio.OptionMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UndertowSSLConfigurationTest {
+
+    private JHipsterProperties properties;
+
+    @Before
+    public void setup() {
+        properties = new JHipsterProperties();
+    }
+
+    @Test
+    public void testUndertowSSLConfigurationOK() {
+        //Prepare
+        UndertowServletWebServerFactory undertowServletWebServerFactory = new UndertowServletWebServerFactory();
+        properties.getHttp().setUseUndertowUserCipherSuitesOrder(true);
+
+        //Execute
+        UndertowSSLConfiguration undertowSSLConfiguration = new UndertowSSLConfiguration(undertowServletWebServerFactory, properties);
+
+        //Verify
+        Undertow.Builder builder = Undertow.builder();
+        undertowServletWebServerFactory.getBuilderCustomizers().forEach(c -> c.customize(builder));
+        OptionMap.Builder serverOptions = (OptionMap.Builder) ReflectionTestUtils.getField(builder, "socketOptions");
+        assertThat(undertowServletWebServerFactory).isNotNull();
+        assertThat(serverOptions.getMap().get(UndertowOptions.SSL_USER_CIPHER_SUITES_ORDER)).isTrue();
+    }
+
+    @Test
+    public void testUndertowSSLConfigurationKO() {
+        //Prepare
+        UndertowServletWebServerFactory undertowServletWebServerFactory = new UndertowServletWebServerFactory();
+        properties.getHttp().setUseUndertowUserCipherSuitesOrder(false);
+
+        //Execute
+        UndertowSSLConfiguration undertowSSLConfiguration = new UndertowSSLConfiguration(undertowServletWebServerFactory, properties);
+
+        //Verify
+        Undertow.Builder builder = Undertow.builder();
+        undertowServletWebServerFactory.getBuilderCustomizers().forEach(c -> c.customize(builder));
+        OptionMap.Builder serverOptions = (OptionMap.Builder) ReflectionTestUtils.getField(builder, "socketOptions");
+        assertThat(undertowServletWebServerFactory).isNotNull();
+        assertThat(serverOptions.getMap().get(UndertowOptions.SSL_USER_CIPHER_SUITES_ORDER)).isNull();
+    }
+
+}


### PR DESCRIPTION
Transfer of the code previously in the jhipster/generator-jhipster

Do you think that I need to do another PR in the jhipster/generator-jhipster for adding the new properties (useUndertowUserCipherSuitesOrder)  / comments in the spring boot config files ?

## Previous description :
It will force the order of the cipher define in the properties file.
The purpose of this is to achieve perfect forward secrecy for SSL (More infos) in combination of the cipher list in the comments SSL section in the spring boot properties file.

It's the missing part of my first PR

The only thing left will be to add this JVM flag
-Djdk.tls.ephemeralDHKeySize=2048

But I don't really know how we can automate this since it depends on the cloud / hosting providers

With all of these the grade in SSLLabs will be A+ instead of B

Tell me what you think about that 😃