### PR TITLE
Use 'dependencies' property

### DIFF
--- a/travis/scripts/00-replace-version-generator.sh
+++ b/travis/scripts/00-replace-version-generator.sh
@@ -4,16 +4,16 @@ if [[ $JHIPSTER_VERSION == '' ]]; then
     JHIPSTER_VERSION=0.0.0-TRAVIS
 fi
 
-# jhipster-framework.version in generated pom.xml or gradle.properties
+# jhipster-dependencies.version in generated pom.xml or gradle.properties
 PREVIOUS_DIR=$(pwd)
 cd $HOME/generator-jhipster/generators/server/templates
 
-sed -e 's/<jhipster-framework.version>.*<\/jhipster-framework.version>/<jhipster-framework.version>'$JHIPSTER_VERSION'<\/jhipster-framework.version>/1;' pom.xml.ejs > pom.xml.ejs.sed
+sed -e 's/<jhipster-dependencies.version>.*<\/jhipster-dependencies.version>/<jhipster-dependencies.version>'$JHIPSTER_VERSION'<\/jhipster-dependencies.version>/1;' pom.xml.ejs > pom.xml.ejs.sed
 mv -f pom.xml.ejs.sed pom.xml.ejs
-cat pom.xml.ejs | grep \<jhipster-framework.version\>
+cat pom.xml.ejs | grep \<jhipster-dependencies.version\>
 
-sed -e 's/jhipster_framework_version=.*/jhipster_framework_version='$JHIPSTER_VERSION'/1;' gradle.properties.ejs > gradle.properties.ejs.sed
+sed -e 's/jhipster_dependencies_version=.*/jhipster_dependencies_version='$JHIPSTER_VERSION'/1;' gradle.properties.ejs > gradle.properties.ejs.sed
 mv -f gradle.properties.ejs.sed gradle.properties.ejs
-cat gradle.properties.ejs | grep jhipster_framework_version=
+cat gradle.properties.ejs | grep jhipster_dependencies_version=
 
 cd "$PREVIOUS_DIR"

--- a/travis/scripts/03-replace-version-generated-project.sh
+++ b/travis/scripts/03-replace-version-generated-project.sh
@@ -4,16 +4,16 @@ if [[ $JHIPSTER_VERSION == '' ]]; then
     JHIPSTER_VERSION=0.0.0-TRAVIS
 fi
 
-# jhipster-framework.version in generated pom.xml or gradle.properties
+# jhipster-dependencies.version in generated pom.xml or gradle.properties
 cd "$APP_FOLDER"
 if [[ -a mvnw ]]; then
-    sed -e 's/<jhipster-framework.version>.*<\/jhipster-framework.version>/<jhipster-framework.version>'$JHIPSTER_VERSION'<\/jhipster-framework.version>/1;' pom.xml > pom.xml.sed
+    sed -e 's/<jhipster-dependencies.version>.*<\/jhipster-dependencies.version>/<jhipster-dependencies.version>'$JHIPSTER_VERSION'<\/jhipster-dependencies.version>/1;' pom.xml > pom.xml.sed
     mv -f pom.xml.sed pom.xml
-    cat pom.xml | grep \<jhipster-framework.version\>
+    cat pom.xml | grep \<jhipster-dependencies.version\>
 
 elif [[ -a gradlew ]]; then
-    sed -e 's/jhipster_framework_version=.*/jhipster_framework_version='$JHIPSTER_VERSION'/1;' gradle.properties > gradle.properties.sed
+    sed -e 's/jhipster_dependencies_version=.*/jhipster_dependencies_version='$JHIPSTER_VERSION'/1;' gradle.properties > gradle.properties.sed
     mv -f gradle.properties.sed gradle.properties
-    cat gradle.properties | grep jhipster_framework_version=
+    cat gradle.properties | grep jhipster_dependencies_version=
 
 fi


### PR DESCRIPTION
@jdubois
Fix the Travis build. No need to re-release the serverside stuff, the deployed artifacts are all right. (Evidence: generator builds are passing).

Things are a bit messy with these Travis scripts, complicated dependencies . When things settle down a bit I'll have a look if that can't be improved somewhat.