### PR TITLE
Add BOM for AWS to ensure aligned dependencies

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -39,7 +39,7 @@
 
     <properties>
         <!-- Dependency versions -->
-        <aws-java-sdk-ssm.version>1.11.312</aws-java-sdk-ssm.version>
+        <aws-java-sdk.version>1.11.313</aws-java-sdk.version>
         <bucket4j.version>3.1.1</bucket4j.version>
         <cassandra-unit-spring.version>3.3.0.2</cassandra-unit-spring.version>
         <couchmove.version>1.0.1</couchmove.version>
@@ -178,11 +178,6 @@
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt</artifactId>
                 <version>${jjwt.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-ssm</artifactId>
-                <version>${aws-java-sdk-ssm.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.sabomichal</groupId>
@@ -670,6 +665,14 @@
             </dependency>
 
             <!-- BOM imports last so we (could) selectively override dependencies above -->
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bom</artifactId>
+                <version>aws-java-sdk.version</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-stream-dependencies</artifactId>

--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -668,7 +668,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>aws-java-sdk.version</version>
+                <version>${aws-java-sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
I was having issues with the Amazon SSM version(**1.11.312**) pulling in an older version of the core library(**1.11.251**), which was causing runtime issues in the ECS container. I wasn't able to determine how maven was resolving to the older library.

Based on the instruction in [this AWS blog post](https://aws.amazon.com/blogs/developer/managing-dependencies-with-aws-sdk-for-java-bill-of-materials-module-bom/), I have added a BOM to ensure there is no mismatch.

```
[INFO] +- com.amazonaws:aws-java-sdk-ssm:jar:1.11.312:compile
[INFO] |  +- com.amazonaws:aws-java-sdk-core:jar:1.11.251:compile (version managed from 1.11.312)
[INFO] |  |  +- org.apache.httpcomponents:httpclient:jar:4.5.5:compile (version managed from 4.5.2)
[INFO] |  |  |  +- org.apache.httpcomponents:httpcore:jar:4.4.9:compile
[INFO] |  |  |  \- commons-codec:commons-codec:jar:1.11:compile (version managed from 1.10)
[INFO] |  |  +- software.amazon.ion:ion-java:jar:1.0.2:compile
[INFO] |  |  +- (com.fasterxml.jackson.core:jackson-databind:jar:2.9.3:compile - version managed from 2.6.7.1; omitted for duplicate)
[INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.9.3:compile (version managed from 2.6.7)
[INFO] |  |  |  \- (com.fasterxml.jackson.core:jackson-core:jar:2.9.3:compile - omitted for duplicate)
[INFO] |  |  \- (joda-time:joda-time:jar:2.9.9:compile - version managed from 2.8.1; omitted for duplicate)
[INFO] |  \- com.amazonaws:jmespath-java:jar:1.11.251:compile (version managed from 1.11.312)
[INFO] |     \- (com.fasterxml.jackson.core:jackson-databind:jar:2.9.3:compile - version managed from 2.6.7.1; omitted for duplicate)
```
I have also updated the version.