### PR TITLE
Specification need to check if the specified field is refered entity or just an atribute

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/service/QueryService.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/QueryService.java
@@ -298,7 +298,7 @@ public abstract class QueryService<ENTITY> {
     protected <X> Specification<ENTITY> byFieldSpecified(SingularAttribute<? super ENTITY, X> field, final boolean
         specified) {
         if(isFieldAnReferringEntity(field)) {
-            return byReferringEntitiesFieldSpecified(field, specified);
+            return byReferringEntitiyFieldSpecified(field, specified);
         }else {
             return specified ? (root, query, builder) -> builder.isNotNull(root.get(field)) : (root, query, builder) ->
                 builder.isNull(root.get(field));
@@ -314,7 +314,7 @@ public abstract class QueryService<ENTITY> {
             builder.isEmpty(root.get(field));
     }
 
-    protected <X> Specification<ENTITY> byReferringEntitiesFieldSpecified(SingularAttribute<? super ENTITY, X> field, final boolean
+    protected <X> Specification<ENTITY> byReferringEntitiyFieldSpecified(SingularAttribute<? super ENTITY, X> field, final boolean
         specified) {
         return specified ? (root, query, builder) -> builder.isNotNull(root.join(field, JoinType.LEFT)) : (root, query, builder) ->
             builder.isNull(root.join(field, JoinType.LEFT));

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/QueryService.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/QueryService.java
@@ -297,16 +297,12 @@ public abstract class QueryService<ENTITY> {
 
     protected <X> Specification<ENTITY> byFieldSpecified(SingularAttribute<? super ENTITY, X> field, final boolean
         specified) {
-        if(isFieldAnReferringEntity(field)) {
+        if(field.isAssociation()) {
             return byReferringEntitiyFieldSpecified(field, specified);
         }else {
             return specified ? (root, query, builder) -> builder.isNotNull(root.get(field)) : (root, query, builder) ->
                 builder.isNull(root.get(field));
         }
-    }
-
-    private boolean isFieldAnReferringEntity(SingularAttribute<? super ENTITY, ?> field) {
-        return field.getType().getJavaType().isInstance(field.getJavaMember().getDeclaringClass()) ? false : true;
     }
 
     protected <X> Specification<ENTITY> byFieldSpecified(SetAttribute<ENTITY, X> field, final boolean specified) {

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/QueryService.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/QueryService.java
@@ -181,7 +181,7 @@ public abstract class QueryService<ENTITY> {
         }
         Specification<ENTITY> result = Specification.where(null);
         if (filter.getSpecified() != null) {
-            result = result.and(byFieldSpecified(reference, filter.getSpecified()));
+            result = result.and(byReferringEntityFieldSpecified(reference, filter.getSpecified()));
         }
         if (filter.getGreaterThan() != null) {
             result = result.and(greaterThan(reference, valueField, filter.getGreaterThan()));
@@ -297,12 +297,8 @@ public abstract class QueryService<ENTITY> {
 
     protected <X> Specification<ENTITY> byFieldSpecified(SingularAttribute<? super ENTITY, X> field, final boolean
         specified) {
-        if(field.isAssociation()) {
-            return byReferringEntitiyFieldSpecified(field, specified);
-        }else {
-            return specified ? (root, query, builder) -> builder.isNotNull(root.get(field)) : (root, query, builder) ->
-                builder.isNull(root.get(field));
-        }
+        return specified ? (root, query, builder) -> builder.isNotNull(root.get(field)) : (root, query, builder) ->
+            builder.isNull(root.get(field));
     }
 
     protected <X> Specification<ENTITY> byFieldSpecified(SetAttribute<ENTITY, X> field, final boolean specified) {
@@ -310,7 +306,7 @@ public abstract class QueryService<ENTITY> {
             builder.isEmpty(root.get(field));
     }
 
-    protected <X> Specification<ENTITY> byReferringEntitiyFieldSpecified(SingularAttribute<? super ENTITY, X> field, final boolean
+    protected <X> Specification<ENTITY> byReferringEntityFieldSpecified(SingularAttribute<? super ENTITY, X> field, final boolean
         specified) {
         return specified ? (root, query, builder) -> builder.isNotNull(root.join(field, JoinType.LEFT)) : (root, query, builder) ->
             builder.isNull(root.join(field, JoinType.LEFT));


### PR DESCRIPTION
Filtering over metamodel should create an outer join when query is
entity?referenceEntityId.specified=boolean

The specification which is build based on an attribute, needs to check if this attribute is a referencing entity or is normal attribute

This is new PR for the new server side lib jhipster-framework which is gone be part o the new version 5.0.0.  PR [#37](https://github.com/jhipster/jhipster/pull/37) is based on top of server side lib jhipster version 1.3.0. I do not know what is intent regarding acceptance of a patch for JHipster V4.

Fixes jhipster/generator-jhipster#6735