### PR TITLE
Add new InfoContributor for mail service

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/config/info/JHipsterInfoContributorConfiguration.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/info/JHipsterInfoContributorConfiguration.java
@@ -41,4 +41,10 @@ public class JHipsterInfoContributorConfiguration {
         ConfigurableEnvironment environment) {
         return new ActiveProfilesInfoContributor(environment);
     }
+
+    @Bean
+    @ConditionalOnEnabledInfoContributor("management.info.mail-enabled.enabled")
+    public MailEnabledInfoContributor mailEnabledInfoContributor() {
+        return new MailEnabledInfoContributor();
+    }
 }

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/info/MailEnabledInfoContributor.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/info/MailEnabledInfoContributor.java
@@ -1,0 +1,23 @@
+package io.github.jhipster.config.info;
+
+import io.github.jhipster.config.JHipsterProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.info.Info;
+import org.springframework.boot.actuate.info.InfoContributor;
+
+/**
+ * An {@link InfoContributor} that tells if mail service is enabled.
+ *
+ */
+public class MailEnabledInfoContributor implements InfoContributor {
+
+    private static final String MAIL_ENABLED = "mailEnabled";
+
+    @Autowired
+    private JHipsterProperties jHipsterProperties;
+
+    @Override
+    public void contribute(Info.Builder builder) {
+        builder.withDetail(MAIL_ENABLED, jHipsterProperties.getMail().isEnabled());
+    }
+}

--- a/jhipster-framework/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/jhipster-framework/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -4,6 +4,12 @@
         "type": "java.lang.Boolean",
         "description": "Enable active-profiles info.",
         "defaultValue": true
+    },
+    {
+        "name": "management.info.mail-enabled.enabled",
+        "type": "java.lang.Boolean",
+        "description": "Enable mail service info",
+        "defaultValue": false
     }
 ]}
 


### PR DESCRIPTION
This is in order to move ``mailEnabled`` property to /info endpoint