### PR TITLE
remove hazelcast session clustering dependency

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -48,7 +48,6 @@
         <cucumber.version>3.0.1</cucumber.version>
         <commons-io.version>2.6</commons-io.version>
         <guava.version>25.1-jre</guava.version>
-        <hazelcast-wm.version>3.8.3</hazelcast-wm.version>
         <infinispan.version>8.2.5.Final</infinispan.version>
         <infinispan-cloud.version>9.1.7.Final</infinispan-cloud.version>
         <infinispan-spring-boot-starter.version>1.0.0.Final</infinispan-spring-boot-starter.version>
@@ -166,11 +165,6 @@
                 <groupId>com.googlecode.xmemcached</groupId>
                 <artifactId>xmemcached</artifactId>
                 <version>${xmemcached.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.hazelcast</groupId>
-                <artifactId>hazelcast-wm</artifactId>
-                <version>${hazelcast-wm.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.infinispan</groupId>


### PR DESCRIPTION
https://github.com/jhipster/generator-jhipster/pull/6944

Support for http session clustering has been removed in above PR.
Better to remove unnecessary deps