### PR TITLE
Swagger enhancement: Allows ignoring predefined response message defa…

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterDefaults.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterDefaults.java
@@ -145,6 +145,7 @@ public interface JHipsterDefaults {
         String defaultIncludePattern = "/api/.*";
         String host = null;
         String[] protocols = {};
+        boolean useDefaultResponseMessages = true;
     }
 
     interface Metrics {

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterProperties.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterProperties.java
@@ -658,6 +658,8 @@ public class JHipsterProperties {
         private String host = JHipsterDefaults.Swagger.host;
 
         private String[] protocols = JHipsterDefaults.Swagger.protocols;
+        
+        private boolean useDefaultResponseMessages = JHipsterDefaults.Swagger.useDefaultResponseMessages;
 
         public String getTitle() {
             return title;
@@ -753,6 +755,14 @@ public class JHipsterProperties {
 
         public void setProtocols(final String[] protocols) {
             this.protocols = protocols;
+        }
+
+        public boolean isUseDefaultResponseMessages() {
+            return useDefaultResponseMessages;
+        }
+
+        public void setUseDefaultResponseMessages(final boolean useDefaultResponseMessages) {
+            this.useDefaultResponseMessages = useDefaultResponseMessages;
         }
     }
 

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/SwaggerAutoConfiguration.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/SwaggerAutoConfiguration.java
@@ -149,6 +149,7 @@ public class SwaggerAutoConfiguration {
 
         return createDocket()
             .apiInfo(apiInfo)
+            .useDefaultResponseMessages(properties.isUseDefaultResponseMessages())
             .groupName(MANAGEMENT_GROUP_NAME)
             .host(properties.getHost())
             .protocols(new HashSet<>(Arrays.asList(properties.getProtocols())))

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/customizer/JHipsterSwaggerCustomizer.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/customizer/JHipsterSwaggerCustomizer.java
@@ -73,6 +73,7 @@ public class JHipsterSwaggerCustomizer implements SwaggerCustomizer, Ordered {
         docket.host(properties.getHost())
             .protocols(new HashSet<>(Arrays.asList(properties.getProtocols())))
             .apiInfo(apiInfo)
+            .useDefaultResponseMessages(properties.isUseDefaultResponseMessages())
             .forCodeGeneration(true)
             .directModelSubstitute(ByteBuffer.class, String.class)
             .genericModelSubstitutes(ResponseEntity.class)

--- a/jhipster-framework/src/test/java/io/github/jhipster/config/JHipsterPropertiesTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/config/JHipsterPropertiesTest.java
@@ -559,6 +559,16 @@ public class JHipsterPropertiesTest {
     }
 
     @Test
+    public void testSwaggerUseDefaultResponseMessages() {
+        JHipsterProperties.Swagger obj = properties.getSwagger();
+        boolean val = JHipsterDefaults.Swagger.useDefaultResponseMessages;
+        assertThat(obj.isUseDefaultResponseMessages()).isEqualTo(val);
+        val = false;
+        obj.setUseDefaultResponseMessages(val);
+        assertThat(obj.isUseDefaultResponseMessages()).isEqualTo(val);
+    }
+
+    @Test
     public void testMetricsJmxEnabled() {
         JHipsterProperties.Metrics.Jmx obj = properties.getMetrics().getJmx();
         boolean val = JHipsterDefaults.Metrics.Jmx.enabled;

--- a/jhipster-framework/src/test/java/io/github/jhipster/config/apidoc/SwaggerAutoConfigurationTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/config/apidoc/SwaggerAutoConfigurationTest.java
@@ -80,6 +80,7 @@ public class SwaggerAutoConfigurationTest {
         properties.setContactUrl("http://test.host.org/contact");
         properties.setLicense("free as in beer");
         properties.setLicenseUrl("http://test.host.org/license");
+        properties.setUseDefaultResponseMessages(false);
 
         config = new SwaggerAutoConfiguration(jHipsterProperties) {
             @Override
@@ -120,6 +121,7 @@ public class SwaggerAutoConfigurationTest {
         assertThat(info.getLicenseUrl()).isEqualTo(properties.getLicenseUrl());
         assertThat(info.getVendorExtensions()).isEmpty();
 
+        verify(docket).useDefaultResponseMessages(properties.isUseDefaultResponseMessages());
         verify(docket).forCodeGeneration(true);
         verify(docket).directModelSubstitute(ByteBuffer.class, String.class);
         verify(docket).genericModelSubstitutes(ResponseEntity.class);
@@ -168,6 +170,7 @@ public class SwaggerAutoConfigurationTest {
         assertThat(info.getLicenseUrl()).isEqualTo("");
         assertThat(info.getVendorExtensions()).isEmpty();
 
+        verify(docket).useDefaultResponseMessages(properties.isUseDefaultResponseMessages());
         verify(docket).forCodeGeneration(true);
         verify(docket).directModelSubstitute(ByteBuffer.class, String.class);
         verify(docket).genericModelSubstitutes(ResponseEntity.class);


### PR DESCRIPTION
…ults (implement field useDefaultResponseMessages)

See:
https://springfox.github.io/springfox/docs/current/#configuration-explained
http://springfox.github.io/springfox/javadoc/current/springfox/documentation/spring/web/plugins/Docket.html#useDefaultResponseMessages-boolean-