### PR TITLE
configures maven pom to produces reports and releases

### DIFF
--- a/jhipster-framework/LICENSE.txt
+++ b/jhipster-framework/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/jhipster-framework/pom.xml
+++ b/jhipster-framework/pom.xml
@@ -200,6 +200,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>

--- a/jhipster-framework/src/main/java/io/github/jhipster/async/ExceptionHandlingAsyncTaskExecutor.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/async/ExceptionHandlingAsyncTaskExecutor.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.async;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.async;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterConstants.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterConstants.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config;
 
 /**
  * JHipster constants.

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterDefaults.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterDefaults.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config;
 
 import java.util.*;
 

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterProperties.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterProperties.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config;
 
 import java.util.List;
 import java.util.Map;

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/PageableParameterBuilderPlugin.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/PageableParameterBuilderPlugin.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.apidoc;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.apidoc;
 
 import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.classmate.TypeResolver;

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/SwaggerAutoConfiguration.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/SwaggerAutoConfiguration.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.apidoc;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.apidoc;
 
 import static io.github.jhipster.config.JHipsterConstants.SPRING_PROFILE_SWAGGER;
 import static springfox.documentation.builders.PathSelectors.regex;

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/SwaggerPluginsAutoConfiguration.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/SwaggerPluginsAutoConfiguration.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2017 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.apidoc;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.apidoc;
 
 import com.fasterxml.classmate.TypeResolver;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/customizer/JHipsterSwaggerCustomizer.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/customizer/JHipsterSwaggerCustomizer.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2017 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.apidoc.customizer;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.apidoc.customizer;
 
 import io.github.jhipster.config.JHipsterProperties;
 import org.springframework.core.Ordered;

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/customizer/SwaggerCustomizer.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/customizer/SwaggerCustomizer.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2017 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.apidoc.customizer;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.apidoc.customizer;
 
 import springfox.documentation.spring.web.plugins.Docket;
 

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/package-info.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/package-info.java
@@ -2,3 +2,23 @@
  * Springfox configuraiton to generate Swagger documentation.
  */
 package io.github.jhipster.config.apidoc;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/h2/H2ConfigurationHelper.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/h2/H2ConfigurationHelper.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.h2;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.h2;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/info/ActiveProfilesInfoContributor.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/info/ActiveProfilesInfoContributor.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.info;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.info;
 
 import org.springframework.boot.actuate.info.Info;
 import org.springframework.boot.actuate.info.InfoContributor;

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/info/JHipsterInfoContributorConfiguration.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/info/JHipsterInfoContributorConfiguration.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.info;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.info;
 
 import org.springframework.boot.actuate.autoconfigure.info.ConditionalOnEnabledInfoContributor;
 import org.springframework.boot.actuate.autoconfigure.info.InfoContributorAutoConfiguration;

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/info/MailEnabledInfoContributor.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/info/MailEnabledInfoContributor.java
@@ -1,5 +1,25 @@
 package io.github.jhipster.config.info;
 
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import io.github.jhipster.config.JHipsterProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.info.Info;

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/jcache/BeanClassLoaderAwareJCacheRegionFactory.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/jcache/BeanClassLoaderAwareJCacheRegionFactory.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.jcache;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.jcache;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/jcache/NoDefaultJCacheRegionFactory.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/jcache/NoDefaultJCacheRegionFactory.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.jcache;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.jcache;
 
 import java.util.Properties;
 import javax.cache.Cache;

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/liquibase/AsyncSpringLiquibase.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/liquibase/AsyncSpringLiquibase.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.liquibase;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.liquibase;
 
 import static io.github.jhipster.config.JHipsterConstants.SPRING_PROFILE_DEVELOPMENT;
 import static io.github.jhipster.config.JHipsterConstants.SPRING_PROFILE_HEROKU;

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/liquibase/package-info.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/liquibase/package-info.java
@@ -2,3 +2,23 @@
  * Liquibase specific code.
  */
 package io.github.jhipster.config.liquibase;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/locale/AngularCookieLocaleResolver.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/locale/AngularCookieLocaleResolver.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.locale;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.locale;
 
 import java.util.Locale;
 import java.util.TimeZone;

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/locale/package-info.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/locale/package-info.java
@@ -2,3 +2,23 @@
  * Locale specific code.
  */
 package io.github.jhipster.config.locale;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/package-info.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/package-info.java
@@ -2,3 +2,23 @@
  * JHipster configuration classes and helpers.
  */
 package io.github.jhipster.config;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */

--- a/jhipster-framework/src/main/java/io/github/jhipster/domain/util/FixedH2Dialect.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/domain/util/FixedH2Dialect.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.domain.util;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.domain.util;
 
 import java.sql.Types;
 

--- a/jhipster-framework/src/main/java/io/github/jhipster/domain/util/FixedPostgreSQL82Dialect.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/domain/util/FixedPostgreSQL82Dialect.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.domain.util;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.domain.util;
 
 import java.sql.Types;
 

--- a/jhipster-framework/src/main/java/io/github/jhipster/domain/util/JSR310DateConverters.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/domain/util/JSR310DateConverters.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.domain.util;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.domain.util;
 
 import java.time.*;
 import java.util.Date;

--- a/jhipster-framework/src/main/java/io/github/jhipster/domain/util/package-info.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/domain/util/package-info.java
@@ -2,3 +2,23 @@
  * Utilities for JHipster domain objects.
  */
 package io.github.jhipster.domain.util;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */

--- a/jhipster-framework/src/main/java/io/github/jhipster/security/AjaxAuthenticationFailureHandler.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/security/AjaxAuthenticationFailureHandler.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.security;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.security;
 
 import java.io.IOException;
 import javax.servlet.ServletException;

--- a/jhipster-framework/src/main/java/io/github/jhipster/security/AjaxAuthenticationSuccessHandler.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/security/AjaxAuthenticationSuccessHandler.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.security;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.security;
 
 import java.io.IOException;
 import javax.servlet.ServletException;

--- a/jhipster-framework/src/main/java/io/github/jhipster/security/AjaxLogoutSuccessHandler.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/security/AjaxLogoutSuccessHandler.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.security;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.security;
 
 import java.io.IOException;
 import javax.servlet.ServletException;

--- a/jhipster-framework/src/main/java/io/github/jhipster/security/PersistentTokenCache.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/security/PersistentTokenCache.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.security;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.security;
 
 import java.util.*;
 

--- a/jhipster-framework/src/main/java/io/github/jhipster/security/package-info.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/security/package-info.java
@@ -2,3 +2,23 @@
  * Security classes and helpers used in JHipster applications.
  */
 package io.github.jhipster.security;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */

--- a/jhipster-framework/src/main/java/io/github/jhipster/security/ssl/UndertowSSLConfiguration.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/security/ssl/UndertowSSLConfiguration.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.security.ssl;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.security.ssl;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/jhipster-framework/src/main/java/io/github/jhipster/security/uaa/LoadBalancedResourceDetails.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/security/uaa/LoadBalancedResourceDetails.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.security.uaa;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.security.uaa;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/jhipster-framework/src/main/java/io/github/jhipster/security/uaa/UaaAutoConfiguration.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/security/uaa/UaaAutoConfiguration.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.security.uaa;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.security.uaa;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/jhipster-framework/src/main/java/io/github/jhipster/security/uaa/package-info.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/security/uaa/package-info.java
@@ -2,3 +2,23 @@
  * Classes and utilities for projects using the JHipster UAA server.
  */
 package io.github.jhipster.security.uaa;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/QueryService.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/QueryService.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service;
 
 import java.util.Collection;
 import java.util.Set;

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/BigDecimalFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/BigDecimalFilter.java
@@ -1,22 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-package io.github.jhipster.service.filter;
 
 import java.math.BigDecimal;
 

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/BooleanFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/BooleanFilter.java
@@ -1,22 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-package io.github.jhipster.service.filter;
 
 /**
  * Class for filtering attributes with {@link Boolean} type. It can be added to a criteria class as a member, to support

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/DoubleFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/DoubleFilter.java
@@ -1,22 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-package io.github.jhipster.service.filter;
 
 /**
  * Filter class for {@link Double} type attributes.

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/Filter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/Filter.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import java.io.Serializable;
 import java.util.List;

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/FloatFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/FloatFilter.java
@@ -1,22 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-package io.github.jhipster.service.filter;
 
 /**
  * Filter class for {@link Float} type attributes.

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/InstantFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/InstantFilter.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import java.time.Instant;
 

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/IntegerFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/IntegerFilter.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 /**
  * Filter class for {@link Integer} type attributes.

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/LocalDateFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/LocalDateFilter.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/LongFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/LongFilter.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 /**
  * Filter class for {@link Long} type attributes.

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/RangeFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/RangeFilter.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import java.util.Objects;
 

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/ShortFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/ShortFilter.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 /**
  * Filter class for {@link Short} type attributes.

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/StringFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/StringFilter.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import java.util.Objects;
 

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/ZonedDateTimeFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/ZonedDateTimeFilter.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import java.time.ZonedDateTime;
 import java.util.List;

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/package-info.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/package-info.java
@@ -2,3 +2,23 @@
  * Utilities for JPA criteria classes, used for filtering data on the back-end.
  */
 package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */

--- a/jhipster-framework/src/main/java/io/github/jhipster/test/LogbackRecorder.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/test/LogbackRecorder.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.test;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.test;
 
 import java.util.*;
 

--- a/jhipster-framework/src/main/java/io/github/jhipster/web/filter/CachingHttpHeadersFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/web/filter/CachingHttpHeadersFilter.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.web.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.web.filter;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;

--- a/jhipster-framework/src/main/java/io/github/jhipster/web/util/ResponseUtil.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/web/util/ResponseUtil.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.web.util;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.web.util;
 
 import java.util.Optional;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/async/ExceptionHandlingAsyncTaskExecutorTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/async/ExceptionHandlingAsyncTaskExecutorTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.async;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.async;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;

--- a/jhipster-framework/src/test/java/io/github/jhipster/config/JHipsterPropertiesTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/config/JHipsterPropertiesTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Lists.newArrayList;

--- a/jhipster-framework/src/test/java/io/github/jhipster/config/apidoc/PageableParameterBuilderPluginTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/config/apidoc/PageableParameterBuilderPluginTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.apidoc;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.apidoc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/jhipster-framework/src/test/java/io/github/jhipster/config/apidoc/SwaggerAutoConfigurationTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/config/apidoc/SwaggerAutoConfigurationTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.apidoc;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.apidoc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/jhipster-framework/src/test/java/io/github/jhipster/config/apidoc/SwaggerPluginsAutoConfigurationTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/config/apidoc/SwaggerPluginsAutoConfigurationTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2017 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.apidoc;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.apidoc;
 
 import com.fasterxml.classmate.TypeResolver;
 import io.github.jhipster.test.LogbackRecorder;

--- a/jhipster-framework/src/test/java/io/github/jhipster/config/jcache/NoDefaultJCacheRegionFactoryTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/config/jcache/NoDefaultJCacheRegionFactoryTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.jcache;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.jcache;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;

--- a/jhipster-framework/src/test/java/io/github/jhipster/config/liquibase/AsyncSpringLiquibaseTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/config/liquibase/AsyncSpringLiquibaseTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.liquibase;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.liquibase;
 
 import static io.github.jhipster.config.JHipsterConstants.SPRING_PROFILE_DEVELOPMENT;
 import static io.github.jhipster.config.JHipsterConstants.SPRING_PROFILE_HEROKU;

--- a/jhipster-framework/src/test/java/io/github/jhipster/config/locale/AngularCookieLocaleResolverTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/config/locale/AngularCookieLocaleResolverTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.config.locale;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.config.locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;

--- a/jhipster-framework/src/test/java/io/github/jhipster/domain/util/FixedH2DialectTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/domain/util/FixedH2DialectTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.domain.util;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.domain.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/domain/util/FixedPostgreSQL82DialectTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/domain/util/FixedPostgreSQL82DialectTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.domain.util;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.domain.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/security/AjaxAuthenticationFailureHandlerTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/security/AjaxAuthenticationFailureHandlerTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.security;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.security;
 
 import static io.github.jhipster.security.AjaxAuthenticationFailureHandler.UNAUTHORIZED_MESSAGE;
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;

--- a/jhipster-framework/src/test/java/io/github/jhipster/security/AjaxAuthenticationSuccessHandlerTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/security/AjaxAuthenticationSuccessHandlerTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.security;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.security;
 
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/jhipster-framework/src/test/java/io/github/jhipster/security/AjaxLogoutSuccessHandlerTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/security/AjaxLogoutSuccessHandlerTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.security;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;

--- a/jhipster-framework/src/test/java/io/github/jhipster/security/PersistentTokenCacheTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/security/PersistentTokenCacheTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.security;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.security;
 
 import org.junit.Test;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/security/ssl/UndertowSSLConfigurationTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/security/ssl/UndertowSSLConfigurationTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.security.ssl;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.security.ssl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/security/uaa/LoadBalancedResourceDetailsTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/security/uaa/LoadBalancedResourceDetailsTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.security.uaa;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.security.uaa;
 
 import static io.github.jhipster.security.uaa.LoadBalancedResourceDetails.EXCEPTION_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/jhipster-framework/src/test/java/io/github/jhipster/security/uaa/UaaAutoConfigurationTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/security/uaa/UaaAutoConfigurationTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.security.uaa;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.security.uaa;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/demo/BaseEntity.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/demo/BaseEntity.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.demo;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.demo;
 
 import javax.persistence.Column;
 import javax.persistence.GeneratedValue;

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/demo/BaseEntityQueryService.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/demo/BaseEntityQueryService.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.demo;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.demo;
 
 import org.springframework.data.jpa.domain.Specification;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/demo/ChildEntity.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/demo/ChildEntity.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.demo;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.demo;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/demo/ChildEntityQueryService.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/demo/ChildEntityQueryService.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.demo;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.demo;
 
 import org.springframework.data.jpa.domain.Specification;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/demo/ParentEntity.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/demo/ParentEntity.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.demo;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.demo;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/filter/BigDecimalFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/filter/BigDecimalFilterTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/filter/BooleanFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/filter/BooleanFilterTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/filter/DoubleFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/filter/DoubleFilterTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/filter/FilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/filter/FilterTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import com.google.common.collect.Lists;
 import org.junit.Before;

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/filter/FloatFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/filter/FloatFilterTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/filter/InstantFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/filter/InstantFilterTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/filter/IntegerFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/filter/IntegerFilterTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/filter/LocalDateFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/filter/LocalDateFilterTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/filter/LongFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/filter/LongFilterTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/filter/RangeFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/filter/RangeFilterTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import com.google.common.collect.Lists;
 import org.junit.Before;

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/filter/ShortFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/filter/ShortFilterTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/filter/StringFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/filter/StringFilterTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import com.google.common.collect.Lists;
 import org.junit.Before;

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/filter/ZonedDateTimeFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/filter/ZonedDateTimeFilterTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.service.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.service.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/jhipster-framework/src/test/java/io/github/jhipster/test/LogbackRecorderTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/test/LogbackRecorderTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.test;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;

--- a/jhipster-framework/src/test/java/io/github/jhipster/web/filter/CachingHttpHeadersFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/web/filter/CachingHttpHeadersFilterTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.web.filter;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.web.filter;
 
 import static io.github.jhipster.web.filter.CachingHttpHeadersFilter.DEFAULT_DAYS_TO_LIVE;
 import static io.github.jhipster.web.filter.CachingHttpHeadersFilter.LAST_MODIFIED;

--- a/jhipster-framework/src/test/java/io/github/jhipster/web/util/ResponseUtilTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/web/util/ResponseUtilTest.java
@@ -1,23 +1,24 @@
-/*
- * Copyright 2016-2018 the original author or authors from the JHipster project.
- *
- * This file is part of the JHipster project, see https://www.jhipster.tech/
- * for more information.
- *
+package io.github.jhipster.web.util;
+
+/*-
+ * #%L
+ * JHipster server-side framework
+ * %%
+ * Copyright (C) 2016 - 2018 JHipster
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
-
-package io.github.jhipster.web.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <name>JHipster server-side parent POM</name>
     <url>https://github.com/jhipster/jhipster/</url>
 
+    <inceptionYear>2016</inceptionYear>
     <licenses>
         <license>
             <name>Apache License, version 2.0</name>
@@ -47,8 +48,10 @@
         <!-- Build properties -->
         <java.version>1.8</java.version>
         <maven.version>3.0.0</maven.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <!-- generic properties -->
+        <encoding>UTF-8</encoding>
+        <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
         <project.testresult.directory>${project.build.directory}/test-results</project.testresult.directory>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -64,24 +67,42 @@
 
         <!-- Plugin versions -->
         <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
+        <license-maven-plugin.version>1.14</license-maven-plugin.version>
+        <maven-checkstyle-plugin.version>2.15</maven-checkstyle-plugin.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+        <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
+        <maven-pmd-plugin.version>3.4</maven-pmd-plugin.version>
+        <maven-project-info-reports-plugin.version>2.8</maven-project-info-reports-plugin.version>
+        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+        <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
+        <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <sonar-maven-plugin.version>3.5.0.1254</sonar-maven-plugin.version>
+        <spotbugs-maven-plugin.version>3.1.6</spotbugs-maven-plugin.version>
+        <versions-maven-plugin.version>2.1</versions-maven-plugin.version>
+
+        <wagon-scm.version>2.12</wagon-scm.version>
+        <org.apache.maven.scm.version>1.9.4</org.apache.maven.scm.version>
+        <maven-scm-manager-plexus.version>${org.apache.maven.scm.version}</maven-scm-manager-plexus.version>
+        <maven-scm-provider-gitexe.version>${org.apache.maven.scm.version}</maven-scm-provider-gitexe.version>
+
     </properties>
 
     <scm>
-        <connection>scm:git:https://github.com/jhipster/jhipster/</connection>
-        <url>https://github.com/jhipster/jhipster/</url>
+        <connection>scm:git:https://github.com/jhipster/jhipster.git</connection>
+        <developerConnection>scm:git:git@github.com:jhipster/jhipster.git</developerConnection>
+        <url>https://github.com/jhipster/jhipster</url>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
+            <id>snapshots</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
+            <id>releases</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
@@ -100,10 +121,6 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
             </plugin>
         </plugins>
         <pluginManagement>
@@ -134,6 +151,39 @@
                                 <dataFile>${project.testresult.directory}/coverage/jacoco/jacoco.exec</dataFile>
                                 <outputDirectory>${project.testresult.directory}/coverage/jacoco</outputDirectory>
                             </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>${license-maven-plugin.version}</version>
+                    <configuration>
+                        <licenseName>apache_v2</licenseName>
+                        <excludes>
+                            <exclude>**/*persistence.xml</exclude>
+                            <exclude>**/*.html</exclude>
+                            <exclude>**/*.json</exclude>
+                            <exclude>**/*.svg</exclude>
+                        </excludes>
+                        <extraExtensions>
+                            <bnd>properties</bnd>
+                        </extraExtensions>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>first</id>
+                            <goals>
+                                <goal>update-file-header</goal>
+                            </goals>
+                            <phase>process-sources</phase>
+                        </execution>
+                        <execution>
+                            <id>second</id>
+                            <goals>
+                                <goal>update-project-license</goal>
+                            </goals>
+                            <phase>process-sources</phase>
                         </execution>
                     </executions>
                 </plugin>
@@ -200,6 +250,10 @@
                             </goals>
                         </execution>
                     </executions>
+                    <configuration>
+                        <keyname>${gpg.keyname}</keyname>
+                        <passphraseServerId>${gpg.passphrase}</passphraseServerId>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -213,6 +267,58 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>${maven-release-plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.scm</groupId>
+                            <artifactId>maven-scm-provider-gitexe</artifactId>
+                            <version>${maven-scm-provider-gitexe.version}</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <scmCommentPrefix>[ci-skip][maven-release-plugin]</scmCommentPrefix>
+                        <!-- The profile we want to use when doing the release -->
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <releaseProfiles>release</releaseProfiles>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>${maven-site-plugin.version}</version>
+                    <configuration>
+                        <inputEncoding>${encoding}</inputEncoding>
+                        <outputEncoding>${encoding}</outputEncoding>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-descriptor</id>
+                            <goals>
+                                <goal>attach-descriptor</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.scm</groupId>
+                            <artifactId>maven-scm-provider-gitexe</artifactId>
+                            <version>${maven-scm-provider-gitexe.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.maven.wagon</groupId>
+                            <artifactId>wagon-scm</artifactId>
+                            <version>${wagon-scm.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.maven.scm</groupId>
+                            <artifactId>maven-scm-manager-plexus</artifactId>
+                            <version>${maven-scm-manager-plexus.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -255,5 +361,174 @@
             </plugins>
         </pluginManagement>
     </build>
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <!--
+                    To release:
 
+                    1 configure a server on your settings.xml
+                    <servers>
+        <server>
+                <id>gitlab-pages</id>
+                <privateKey>${user.home}/.ssh/id_rsa</privateKey>
+                <configuration>
+                        <scmVersionType>branch</scmVersionType>
+                        <scmVersion>gh-pages</scmVersion>
+                </configuration>
+        </server>
+        <server>
+      <id>gpg.passphrase</id>
+      <passphrase><![CDATA[xxxxx]]></passphrase>
+    </server>
+    <server>
+      <id>snapshots</id>
+      <username>snapshotrepo</username>
+      <password><![CDATA[xxxxx]]></password>
+    </server>
+    <server>
+      <id>releases</id>
+      <username>releaserepo</username>
+      <password><![CDATA[xxxxx]]></password>
+    </server>
+    <server>
+    ...
+    <profiles>
+    <profile>
+      <id>release</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+          <gpg.keyname>xxxxx</gpg.keyname>
+        <gpg.passphrase><![CDATA[cccccc]]></gpg.passphrase>
+      </properties>
+    </profile>
+<profile>
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-release-plugin</artifactId>
+                        <configuration>
+                            <goals>deploy site-deploy</goals>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+    <reporting>
+        <plugins>
+            <!-- not working in the build pipeline <plugin> <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-changelog-plugin</artifactId> <version>${maven-changelog-plugin.version}</version>
+                </plugin> -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <!-- select non-aggregate reports -->
+                            <report>report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+                <configuration>
+                    <dataFile>${sonar.jacoco.reportPath}</dataFile>
+                    <outputDirectory>${sonar.jacoco.reportFolder}</outputDirectory>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <reportSets>
+                    <reportSet>
+                        <id>jdoc</id>
+                        <reports>
+                            <report>javadoc</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+                <version>${maven-jxr-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>${maven-pmd-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>${maven-project-info-reports-plugin.version}</version>
+                <configuration>
+                    <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
+                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${spotbugs-maven-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>${versions-maven-plugin.version}</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>dependency-updates-report</report>
+                            <report>plugin-updates-report</report>
+                            <report>property-updates-report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
 </project>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  #%L
+  Pmi
+  %%
+  Copyright (C) 2018 THALESGROUP
+  %%
+  Copyright © 2015-2018 Thales Global Services
+   Licensed under the Thales Inner Source Software License (
+   Version 1.0, InnerPublic - OuterRestricted
+   the "License")
+   You may not use this file except in compliance with the License.
+   You may obtain a copy of the License at https://bit.ly/2HPVKx4
+   See the License for the specific language governing permissions and limitations under the license
+  #L%
+  -->
+
+
+<project name="tmp" xmlns="http://maven.apache.org/DECORATION/1.7.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.7.0 http://maven.apache.org/xsd/decoration-1.7.0.xsd">
+
+    <bannerLeft>
+        <name>Github</name>
+        <!-- this should not be the right adress-->
+        <href>https://github.com/jhipster/jhipster/</href>
+    </bannerLeft>
+
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>1.7</version>
+    </skin>
+    <custom>
+        <fluidoSkin>
+            <sideBarEnabled>true</sideBarEnabled>
+            <topBarEnabled>true</topBarEnabled>
+
+            <googleSearch>
+                <sitesearch />
+            </googleSearch>
+            <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+            <googlePlusOne />
+            <twitter>
+                <user>java_hipster</user>
+                <showUser>true</showUser>
+                <showFollowers>true</showFollowers>
+            </twitter>
+            <facebookLike />
+        </fluidoSkin>
+        <!-- this should not be the right adress-->
+        <custom.fluidoSkin.googleSearch.sitesearch>https://github.com/jhipster/jhipster/tree/gh-pages</custom.fluidoSkin.googleSearch.sitesearch>
+    </custom>
+
+
+    <body>
+    <links>
+        <item name="Jhipster generator repo" href="https://github.com/jhipster/generator-jhipster" />
+    </links>
+
+    <menu name="Documentation">
+        <item href="doc.html" name="Documentation" />
+    </menu>
+    <menu ref="reports" inherit="bottom" />
+    </body>
+</project>


### PR DESCRIPTION
Enables some nice capabilities to Jhipster repo maintainers:

- Ability to release a snapshot pom using these two commands
```
./mvnw release:prepare --batch-mode -Prelease -s /.../settings.xml
./mvnw release:perform --batch-mode -Prelease -s /.../settings.xml
```
This release will increment SNAPSHOT to version to SNAPSHOT+1, tag release version.

- Generates a site listing dependencies or plugins upgrade (mvn site, or on the gh-pages branch after a release), which could be useful for maintaining bom

- Generates License headers automatically (that's the reason of all files modification).

Only the parent pom has been edited, and a new src/site/site.xml file at the root
