### PR TITLE
Update Spring-boot version to 2.0.6 & dependencies

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -59,7 +59,7 @@
         <liquibase-mssql.version>1.6.4</liquibase-mssql.version>
         <liquibase-slf4j.version>2.0.0</liquibase-slf4j.version>
         <logstash-logback-encoder.version>5.2</logstash-logback-encoder.version>
-        <lz4-java.version>1.4.1</lz4-java.version>
+        <lz4-java.version>1.5.0</lz4-java.version>
         <metrics-spring.version>3.1.3</metrics-spring.version>
         <mongobee.version>0.13</mongobee.version>
         <mssql-jdbc.version>7.0.0.jre8</mssql-jdbc.version>

--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -71,7 +71,7 @@
         <spring-data-jest.version>3.1.5.RELEASE</spring-data-jest.version>
         <spring-cloud.version>Finchley.SR1</spring-cloud.version>
         <spring-security-jwt.version>1.0.9.RELEASE</spring-security-jwt.version>
-        <spring-security-oauth.version>2.3.3.RELEASE</spring-security-oauth.version>
+        <spring-security-oauth.version>2.3.4.RELEASE</spring-security-oauth.version>
         <spring-security-oauth2-autoconfigure.version>2.0.5.RELEASE</spring-security-oauth2-autoconfigure.version>
         <springfox.version>2.9.2</springfox.version>
         <xmemcached.version>2.4.5</xmemcached.version>

--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -72,7 +72,7 @@
         <spring-cloud.version>Finchley.SR1</spring-cloud.version>
         <spring-security-jwt.version>1.0.9.RELEASE</spring-security-jwt.version>
         <spring-security-oauth.version>2.3.4.RELEASE</spring-security-oauth.version>
-        <spring-security-oauth2-autoconfigure.version>2.0.5.RELEASE</spring-security-oauth2-autoconfigure.version>
+        <spring-security-oauth2-autoconfigure.version>2.0.6.RELEASE</spring-security-oauth2-autoconfigure.version>
         <springfox.version>2.9.2</springfox.version>
         <xmemcached.version>2.4.5</xmemcached.version>
         <xmemcached-provider.version>4.0.0</xmemcached-provider.version>

--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -40,7 +40,7 @@
     <properties>
         <!-- Dependency versions -->
         <aws-java-sdk-bom.version>1.11.429</aws-java-sdk-bom.version>
-        <bucket4j.version>4.0.1</bucket4j.version>
+        <bucket4j.version>4.1.1</bucket4j.version>
         <cassandra-unit-spring.version>3.5.0.1</cassandra-unit-spring.version>
         <couchmove.version>1.0.2</couchmove.version>
         <couchbase-testcontainer.version>1.3</couchbase-testcontainer.version>

--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -44,7 +44,7 @@
         <cassandra-unit-spring.version>3.5.0.1</cassandra-unit-spring.version>
         <couchmove.version>1.0.2</couchmove.version>
         <couchbase-testcontainer.version>1.3</couchbase-testcontainer.version>
-        <couchbase-client.version>2.6.2</couchbase-client.version>
+        <couchbase-java-client.version>2.7.0</couchbase-java-client.version>
         <couchbase-encryption.version>1.0.0</couchbase-encryption.version>
         <cucumber.version>3.0.2</cucumber.version>
         <commons-io.version>2.6</commons-io.version>
@@ -246,7 +246,7 @@
             <dependency>
                 <groupId>com.couchbase.client</groupId>
                 <artifactId>java-client</artifactId>
-                <version>${couchbase-client.version}</version>
+                <version>${couchbase-java-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.couchbase.client</groupId>

--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -39,7 +39,7 @@
 
     <properties>
         <!-- Dependency versions -->
-        <aws-java-sdk-bom.version>1.11.409</aws-java-sdk-bom.version>
+        <aws-java-sdk-bom.version>1.11.429</aws-java-sdk-bom.version>
         <bucket4j.version>4.0.1</bucket4j.version>
         <cassandra-unit-spring.version>3.5.0.1</cassandra-unit-spring.version>
         <couchmove.version>1.0.2</couchmove.version>

--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -46,7 +46,7 @@
         <couchbase-testcontainer.version>1.3</couchbase-testcontainer.version>
         <couchbase-java-client.version>2.7.0</couchbase-java-client.version>
         <couchbase-encryption.version>1.0.0</couchbase-encryption.version>
-        <cucumber.version>3.0.2</cucumber.version>
+        <cucumber-jvm.version>4.0.2</cucumber-jvm.version>
         <commons-io.version>2.6</commons-io.version>
         <guava.version>25.1-jre</guava.version>
         <!-- The hibernate version should match the one managed by
@@ -123,12 +123,12 @@
             <dependency>
                 <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-junit</artifactId>
-                <version>${cucumber.version}</version>
+                <version>${cucumber-jvm.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-spring</artifactId>
-                <version>${cucumber.version}</version>
+                <version>${cucumber-jvm.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.0.5.RELEASE</version>
+        <version>2.0.6.RELEASE</version>
         <relativePath />
     </parent>
 
@@ -42,7 +42,7 @@
         <!-- The jhipster-framework version should be the same as the artifact version above -->
         <jhipster-framework.version>2.0.26</jhipster-framework.version>
         <!-- The spring-boot version should be the same as the parent version above -->
-        <spring-boot.version>2.0.5.RELEASE</spring-boot.version>
+        <spring-boot.version>2.0.6.RELEASE</spring-boot.version>
 
         <!-- Build properties -->
         <java.version>1.8</java.version>


### PR DESCRIPTION
Included fix for 2 CVEs: https://spring.io/blog/2018/10/16/spring-project-vulnerability-reports-published