### PR TITLE
Fix version CICD when changing [ci skip]

### DIFF
--- a/travis/scripts/00-replace-version-generator.sh
+++ b/travis/scripts/00-replace-version-generator.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $JHIPSTER_VERSION == '' ]]; then
-    JHIPSTER_VERSION=0.0.0-TRAVIS
+    JHIPSTER_VERSION=0.0.0-CICD
 fi
 
 # jhipster-dependencies.version in generated pom.xml or gradle.properties


### PR DESCRIPTION
It's to be consistent with https://github.com/jhipster/generator-jhipster/blob/master/test-integration/scripts/13-replace-version-generated-project.sh#L13