### PR TITLE
Force ElasticSearch version

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -78,6 +78,7 @@
         <springfox.version>2.9.2</springfox.version>
         <xmemcached.version>2.4.5</xmemcached.version>
         <xmemcached-provider.version>4.1.1</xmemcached-provider.version>
+        <elasticsearch.version>6.2.2</elasticsearch.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Spring boot POM dependencies set ElasticSearch 6.4.3 but we are using spring data jest and spring data elasticSearch that need ElasticSearch 6.2.2.
We can't use ElasticSearch 6.4.3 yet because the move some method from XContentBuilder and it's break at server startup.

Maybe we should remove it when spring data jest will handle 6.3+

#8683