### PR TITLE
Ignore Pageable parameters in springfox

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/SwaggerAutoConfiguration.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/SwaggerAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.*;
 import org.springframework.context.annotation.*;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StopWatch;
 import org.springframework.util.StringUtils;
@@ -156,6 +157,7 @@ public class SwaggerAutoConfiguration {
             .forCodeGeneration(true)
             .directModelSubstitute(ByteBuffer.class, String.class)
             .genericModelSubstitutes(ResponseEntity.class)
+            .ignoredParameterTypes(Pageable.class)
             .select()
             .paths(regex(managementContextPath + ".*"))
             .build();

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/customizer/JHipsterSwaggerCustomizer.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/apidoc/customizer/JHipsterSwaggerCustomizer.java
@@ -21,6 +21,7 @@ package io.github.jhipster.config.apidoc.customizer;
 
 import io.github.jhipster.config.JHipsterProperties;
 import org.springframework.core.Ordered;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.Contact;
@@ -77,6 +78,7 @@ public class JHipsterSwaggerCustomizer implements SwaggerCustomizer, Ordered {
             .forCodeGeneration(true)
             .directModelSubstitute(ByteBuffer.class, String.class)
             .genericModelSubstitutes(ResponseEntity.class)
+            .ignoredParameterTypes(Pageable.class)
             .select()
             .paths(regex(properties.getDefaultIncludePattern()))
             .build();


### PR DESCRIPTION
Otherwise you get the internal parameters "offset", "pageNumber", "pageSize", "paged", "sort.sorted", "sort.unsorted", "unpaged" which you don't want to see.