### PR TITLE
update sb-2.1.1

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -55,7 +55,7 @@
         https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/${spring-boot.version} -->
         <hibernate.version>5.3.7.Final</hibernate.version>
         <infinispan.version>9.4.5.Final</infinispan.version>
-        <infinispan-spring-boot-starter-embedded.version>2.1.1.Final</infinispan-spring-boot-starter-embedded.version>
+        <infinispan-spring-boot-starter-embedded.version>2.0.0.Final</infinispan-spring-boot-starter-embedded.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb-impl.version>2.3.1</jaxb-impl.version>
         <jjwt.version>0.10.5</jjwt.version>


### PR DESCRIPTION
- update infinispan sb version

infinispan 2.1.1 seems to have some issues with actuator integration while using non-native cache like JCache