### PR TITLE
update JEST version

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -68,7 +68,7 @@
         <problem-spring-web.version>0.23.0</problem-spring-web.version>
         <prometheus-simpleclient.version>0.5.0</prometheus-simpleclient.version>
         <reflections.version>0.9.11</reflections.version>
-        <spring-data-jest.version>3.1.5.RELEASE</spring-data-jest.version>
+        <spring-data-jest.version>3.2.0.RELEASE</spring-data-jest.version>
         <spring-cloud.version>Finchley.SR2</spring-cloud.version>
         <spring-security-jwt.version>1.0.9.RELEASE</spring-security-jwt.version>
         <spring-security-oauth.version>2.3.4.RELEASE</spring-security-oauth.version>


### PR DESCRIPTION
Fixes id as string issues with Elastic (they should be annotated by `@Field(type = FieldType.Keyword)` but do not have to implement a manual `@Mapping`anymore