### PR TITLE
Maven fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
         <!-- Build properties -->
         <java.version>1.8</java.version>
-        <maven.version>3.0.0</maven.version>
+        <maven.version>3.3.9</maven.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.testresult.directory>${project.build.directory}/test-results</project.testresult.directory>
@@ -180,6 +180,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${maven-enforcer-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>enforce-versions</id>
@@ -277,6 +278,11 @@
                     <groupId>org.sonarsource.scanner.maven</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
                     <version>${sonar-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>${versions-maven-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Repeating my comment from the initial closed PR #155 

I have used the [versions-maven-plugin](https://www.mojohaus.org/versions-maven-plugin/index.html#) to check for plugin updates and had the following output:
```
pav@PAV-UBUNTU:jhipster$ mvn versions:display-plugin-updates
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 3 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 3 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO]
[INFO] JHipster server-side parent POM                                    [pom]
[INFO] JHipster server-side dependencies                                  [pom]
[INFO] JHipster server-side framework                                     [jar]
[INFO]
[INFO] -----------------< io.github.jhipster:jhipster-parent >-----------------
[INFO] Building JHipster server-side parent POM 2.2.0-SNAPSHOT            [1/3]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- versions-maven-plugin:2.7:display-plugin-updates (default-cli) @ jhipster-parent ---
[INFO]
[INFO] All plugins with a version specified are using the latest versions.
[INFO]
[WARNING] The following plugins do not have their version specified:
[WARNING]   maven-enforcer-plugin ................................. 3.0.0-M2
[INFO]
[INFO] Project inherits minimum Maven version as: 3.0.0
[INFO] Plugins require minimum Maven version of: 3.3.9
[INFO]
[ERROR] Project requires an incorrect minimum version of Maven.
[ERROR] Update the pom.xml to contain maven-enforcer-plugin to
[ERROR] force the Maven version which is needed to build this project.
[ERROR] See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
[ERROR] Using the minimum version of Maven: 3.0.0
[INFO]
[INFO] Require Maven 3.0.4 to use the following plugin updates:
[INFO]   maven-compiler-plugin .............................. 3.8.0 -> 3.7.0
[INFO]   maven-source-plugin ......................................... 3.0.1
[INFO]   org.sonatype.plugins:nexus-staging-maven-plugin ............. 1.6.8
[INFO]
[INFO] Require Maven 3.0.5 to use the following plugin updates:
[INFO]   maven-compiler-plugin ....................................... 3.8.0
[INFO]   maven-surefire-plugin .......................... 2.22.1 -> 3.0.0-M3
[INFO]   org.sonarsource.scanner.maven:sonar-maven-plugin ....... 3.5.0.1254
[INFO]
[INFO] Require Maven 3.3.9 to use the following plugin updates:
[INFO]   org.jacoco:jacoco-maven-plugin .............................. 0.8.2
[INFO]
[INFO]
[INFO] --------------< io.github.jhipster:jhipster-dependencies >--------------
[INFO] Building JHipster server-side dependencies 2.2.0-SNAPSHOT          [2/3]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- versions-maven-plugin:2.7:display-plugin-updates (default-cli) @ jhipster-dependencies ---
[INFO]
[INFO] All plugins with a version specified are using the latest versions.
[INFO]
[INFO] All plugins have a version specified.
[INFO]
[INFO] Project inherits minimum Maven version as: 3.0.0
[INFO] Plugins require minimum Maven version of: null
[INFO]
[INFO] No plugins require a newer version of Maven than specified by the pom.
[INFO]
[INFO]
[INFO] ---------------< io.github.jhipster:jhipster-framework >----------------
[INFO] Building JHipster server-side framework 2.2.0-SNAPSHOT             [3/3]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- versions-maven-plugin:2.7:display-plugin-updates (default-cli) @ jhipster-framework ---
[INFO]
[INFO] All plugins with a version specified are using the latest versions.
[INFO]
[INFO] All plugins have a version specified.
[INFO]
[INFO] Project inherits minimum Maven version as: 3.0.0
[INFO] Plugins require minimum Maven version of: null
[INFO]
[INFO] No plugins require a newer version of Maven than specified by the pom.
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for JHipster server-side parent POM 2.2.0-SNAPSHOT:
[INFO]
[INFO] JHipster server-side parent POM .................... SUCCESS [  1.077 s]
[INFO] JHipster server-side dependencies .................. SUCCESS [  0.038 s]
[INFO] JHipster server-side framework ..................... SUCCESS [  0.043 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.993 s
[INFO] Finished at: 2019-01-15T09:22:56+02:00
[INFO] ------------------------------------------------------------------------
```

From this you can see the following issues:
1. The following plugins do not have their version specified: `maven-enforcer-plugin`
2. Plugins require minimum Maven version of: 3.3.9 which is required by `org.jacoco:jacoco-maven-plugin`

Since the maven wrapper was already using version 3.5.2(up until I made a PR for 3.6.0) I think it is not unreasonable to require a higher version as it is also required by the used plugins. Please also note that if I am not mistaken that this affects only the developers of this jhipster project and not users who use jhipster as a dependency, i.e. generated apps.

Finally, I left the definition of the [versions-maven-plugin](https://www.mojohaus.org/versions-maven-plugin/index.html#) within the POM as I have used it a lot and with great success in the past for the following tasks which I guess are also a great part of this project:
1. Check for plugin updates and min required versions, etc. e.g. `mvn versions:display-plugin-updates`. See also [Checking for new plugin updates](https://www.mojohaus.org/versions-maven-plugin/examples/display-plugin-updates.html)
2. Check for dependency updates, e.g. `mvn versions:display-dependency-updates`. See also [Checking for new dependency updates](https://www.mojohaus.org/versions-maven-plugin/examples/display-dependency-updates.html). Although I guess this is kind of limited to what current dependency versions Spring Boot defines.
3. You can compare dependencies with another POM/BOM. For example in this case it would be useful to compare against the current spring boot version, e.g. Running the following : `mvn versions:compare-dependencies -DremotePom=org.springframework.boot:spring-boot-dependencies:2.1.2.RELEASE` yields the following output:
```
pav@PAV-UBUNTU:jhipster$ mvn versions:compare-dependencies -DremotePom=org.springframework.boot:spring-boot-dependencies:2.1.2.RELEASE
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 3 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 3 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] JHipster server-side parent POM                                    [pom]
[INFO] JHipster server-side dependencies                                  [pom]
[INFO] JHipster server-side framework                                     [jar]
[INFO] 
[INFO] -----------------< io.github.jhipster:jhipster-parent >-----------------
[INFO] Building JHipster server-side parent POM 2.2.0-SNAPSHOT            [1/3]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.7:compare-dependencies (default-cli) @ jhipster-parent ---
[INFO] The following differences were found:
[INFO]   none
[INFO] The following property differences were found:
[INFO]   none
[INFO] 
[INFO] --------------< io.github.jhipster:jhipster-dependencies >--------------
[INFO] Building JHipster server-side dependencies 2.2.0-SNAPSHOT          [2/3]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.7:compare-dependencies (default-cli) @ jhipster-dependencies ---
[INFO] The following differences were found:
[INFO]   com.microsoft.sqlserver:mssql-jdbc ......... 7.0.0.jre8 -> 6.4.0.jre8
[INFO]   org.elasticsearch:elasticsearch ...................... 6.2.2 -> 6.4.3
[INFO]   org.elasticsearch.client:transport ................... 6.2.2 -> 6.4.3
[INFO]   org.elasticsearch.distribution.integ-test-zip:elasticsearch  6.2.2 -> 6.4.3
[INFO]   org.elasticsearch.plugin:transport-netty4-client ..... 6.2.2 -> 6.4.3
[INFO]   org.elasticsearch.client:elasticsearch-rest-client ... 6.2.2 -> 6.4.3
[INFO]   org.elasticsearch.client:elasticsearch-rest-high-level-client  6.2.2 -> 6.4.3
[INFO] The following property differences were found:
[INFO]   none
[INFO] 
[INFO] ---------------< io.github.jhipster:jhipster-framework >----------------
[INFO] Building JHipster server-side framework 2.2.0-SNAPSHOT             [3/3]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.7:compare-dependencies (default-cli) @ jhipster-framework ---
[INFO] The following differences were found:
[INFO]   com.microsoft.sqlserver:mssql-jdbc ......... 7.0.0.jre8 -> 6.4.0.jre8
[INFO]   org.elasticsearch:elasticsearch ...................... 6.2.2 -> 6.4.3
[INFO]   org.elasticsearch.client:transport ................... 6.2.2 -> 6.4.3
[INFO]   org.elasticsearch.distribution.integ-test-zip:elasticsearch  6.2.2 -> 6.4.3
[INFO]   org.elasticsearch.plugin:transport-netty4-client ..... 6.2.2 -> 6.4.3
[INFO]   org.elasticsearch.client:elasticsearch-rest-client ... 6.2.2 -> 6.4.3
[INFO]   org.elasticsearch.client:elasticsearch-rest-high-level-client  6.2.2 -> 6.4.3
[INFO] The following property differences were found:
[INFO]   none
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for JHipster server-side parent POM 2.2.0-SNAPSHOT:
[INFO] 
[INFO] JHipster server-side parent POM .................... SUCCESS [  0.563 s]
[INFO] JHipster server-side dependencies .................. SUCCESS [  0.023 s]
[INFO] JHipster server-side framework ..................... SUCCESS [  0.030 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.711 s
[INFO] Finished at: 2019-01-15T10:11:15+02:00
[INFO] ------------------------------------------------------------------------
```
Here it shows that both elastic and mssql driver are left a bit behind. Not sure if that is on purpose though and should be manually checked by a core developer. In any case, I find it very useful and especially for dependencies such as hibernate as per comments within the POM.