### PR TITLE
add support for the java.time.Duration type

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/domain/util/JSR310DateConverters.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/domain/util/JSR310DateConverters.java
@@ -107,4 +107,30 @@ public final class JSR310DateConverters {
             return source == null ? null : LocalDateTime.ofInstant(source.toInstant(), ZoneId.systemDefault());
         }
     }
+
+    public static class DurationToLongConverter implements Converter<Duration, Long> {
+
+        public static final DurationToLongConverter INSTANCE = new DurationToLongConverter();
+
+        private DurationToLongConverter() {
+        }
+
+        @Override
+        public Long convert(Duration source) {
+            return source == null ? null : source.toMillis();
+        }
+    }
+
+    public static class LongToDurationConverter implements Converter<Long, Duration> {
+
+        public static final LongToDurationConverter INSTANCE = new LongToDurationConverter();
+
+        private LongToDurationConverter() {
+        }
+
+        @Override
+        public Duration convert(Long source) {
+            return source == null ? null : Duration.ofMillis(source);
+        }
+    }
 }


### PR DESCRIPTION
This adds the converters for the java.time.Duration for the Mongo driver.