### PR TITLE
Remove invalid character from jhi-metrics endpoint

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/config/metric/JHipsterMetricsEndpoint.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/metric/JHipsterMetricsEndpoint.java
@@ -12,7 +12,7 @@ import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-@WebEndpoint(id = "jhi-metrics")
+@WebEndpoint(id = "jhimetrics")
 public class JHipsterMetricsEndpoint {
 
     private final MeterRegistry meterRegistry;


### PR DESCRIPTION
As discussed with @pascalgrimaud and @PierreBesson, remove invalid character from jhi-metrics to remove the error in the console when launching the app