### PR TITLE
Enable i18n/translation option for HeaderUtil

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterDefaults.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterDefaults.java
@@ -208,4 +208,10 @@ public interface JHipsterDefaults {
 
         String password = null;
     }
+
+    interface ClientApp {
+
+        String name = "jhipsterApp";
+    }
+
 }

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterProperties.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterProperties.java
@@ -19,7 +19,6 @@
 
 package io.github.jhipster.config;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.validation.constraints.NotNull;
@@ -67,6 +66,8 @@ public class JHipsterProperties {
 
     private final Registry registry = new Registry();
 
+    private final ClientApp clientApp = new ClientApp();
+
     public Async getAsync() {
         return async;
     }
@@ -113,6 +114,10 @@ public class JHipsterProperties {
 
     public Gateway getGateway() {
         return gateway;
+    }
+
+    public ClientApp getClientApp() {
+        return clientApp;
     }
 
     public static class Async {
@@ -937,6 +942,19 @@ public class JHipsterProperties {
 
         public void setPassword(String password) {
             this.password = password;
+        }
+    }
+
+    public static class ClientApp {
+
+        private String name = JHipsterDefaults.ClientApp.name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
         }
     }
 }

--- a/jhipster-framework/src/main/java/io/github/jhipster/web/util/HeaderUtil.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/web/util/HeaderUtil.java
@@ -11,13 +11,7 @@ public final class HeaderUtil {
 
     private static final Logger log = LoggerFactory.getLogger(HeaderUtil.class);
 
-    public static final String APPLICATION_NAME = "JHIPSTER";
-
     private HeaderUtil() {
-    }
-
-    public static HttpHeaders createAlert(String message, String param) {
-        return createAlert(APPLICATION_NAME, message, param);
     }
 
     public static HttpHeaders createAlert(String applicationName, String message, String param) {
@@ -27,38 +21,31 @@ public final class HeaderUtil {
         return headers;
     }
 
-    public static HttpHeaders createEntityCreationAlert(String entityName, String param) {
-        return createEntityCreationAlert(APPLICATION_NAME, entityName, param);
+    public static HttpHeaders createEntityCreationAlert(String applicationName, boolean enableTranslation, String entityName, String param) {
+        String message = enableTranslation ? applicationName + "." + entityName + ".created"
+            : "A new " + entityName + " is created with identifier " + param;
+        return createAlert(applicationName, message, param);
     }
 
-    public static HttpHeaders createEntityCreationAlert(String applicationName, String entityName, String param) {
-        return createAlert(applicationName + "." + entityName + ".created", param);
+    public static HttpHeaders createEntityUpdateAlert(String applicationName, boolean enableTranslation, String entityName, String param) {
+        String message = enableTranslation ? applicationName + "." + entityName + ".updated"
+            : "A " + entityName + " is updated with identifier " + param;
+        return createAlert(applicationName, message, param);
     }
 
-    public static HttpHeaders createEntityUpdateAlert(String entityName, String param) {
-        return createEntityUpdateAlert(APPLICATION_NAME, entityName, param);
+    public static HttpHeaders createEntityDeletionAlert(String applicationName, boolean enableTranslation, String entityName, String param) {
+        String message = enableTranslation ? applicationName + "." + entityName + ".deleted"
+            : "A " + entityName + " is deleted with identifier " + param;
+        return createAlert(applicationName, message, param);
     }
 
-    public static HttpHeaders createEntityUpdateAlert(String applicationName, String entityName, String param) {
-        return createAlert(applicationName + "." + entityName + ".updated", param);
-    }
-
-    public static HttpHeaders createEntityDeletionAlert(String entityName, String param) {
-        return createEntityDeletionAlert(APPLICATION_NAME, entityName, param);
-    }
-
-    public static HttpHeaders createEntityDeletionAlert(String applicationName, String entityName, String param) {
-        return createAlert(applicationName + "." + entityName + ".deleted", param);
-    }
-
-    public static HttpHeaders createFailureAlert(String entityName, String errorKey, String defaultMessage) {
-        return createFailureAlert(APPLICATION_NAME, entityName, errorKey, defaultMessage);
-    }
-
-    public static HttpHeaders createFailureAlert(String applicationName, String entityName, String errorKey, String defaultMessage) {
+    public static HttpHeaders createFailureAlert(String applicationName, boolean enableTranslation, String entityName, String errorKey, String defaultMessage) {
         log.error("Entity processing failed, {}", defaultMessage);
+
+        String message = enableTranslation ? "error." + errorKey : defaultMessage;
+
         HttpHeaders headers = new HttpHeaders();
-        headers.add("X-" + applicationName + "-error", "error." + errorKey);
+        headers.add("X-" + applicationName + "-error", message);
         headers.add("X-" + applicationName + "-params", entityName);
         return headers;
     }

--- a/jhipster-framework/src/test/java/io/github/jhipster/config/JHipsterPropertiesTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/config/JHipsterPropertiesTest.java
@@ -707,4 +707,14 @@ public class JHipsterPropertiesTest {
         obj.setUseUndertowUserCipherSuitesOrder(val);
         assertThat(obj.isUseUndertowUserCipherSuitesOrder()).isEqualTo(val);
     }
+
+    @Test
+    public void testClientAppName() {
+        JHipsterProperties.ClientApp obj = properties.getClientApp();
+        String val = JHipsterDefaults.ClientApp.name;
+        assertThat(obj.getName()).isEqualTo(val);
+        val = "1" + val;
+        obj.setName(val);
+        assertThat(obj.getName()).isEqualTo(val);
+    }
 }

--- a/jhipster-framework/src/test/java/io/github/jhipster/web/util/HeaderUtilTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/web/util/HeaderUtilTest.java
@@ -1,0 +1,72 @@
+package io.github.jhipster.web.util;
+
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+
+import static org.junit.Assert.*;
+
+public class HeaderUtilTest {
+
+    @Test
+    public void createAlert() {
+        String message = "any.message";
+        String param = "24";
+
+        HttpHeaders headers = HeaderUtil.createAlert("myApp", message, param);
+        assertEquals(message, headers.getFirst("X-myApp-alert"));
+        assertEquals(param, headers.getFirst("X-myApp-params"));
+    }
+
+    @Test
+    public void createEntityCreationAlertWithTranslation() {
+        HttpHeaders headers = HeaderUtil.createEntityCreationAlert("myApp", true, "User","2");
+        assertEquals("myApp.User.created", headers.getFirst("X-myApp-alert"));
+        assertEquals("2", headers.getFirst("X-myApp-params"));
+    }
+    @Test
+    public void createEntityCreationAlertNoTranslation() {
+        HttpHeaders headers = HeaderUtil.createEntityCreationAlert("myApp", false, "User","2");
+        assertEquals("A new User is created with identifier 2", headers.getFirst("X-myApp-alert"));
+        assertEquals("2", headers.getFirst("X-myApp-params"));
+    }
+
+    @Test
+    public void createEntityUpdateAlertWithTranslation() {
+        HttpHeaders headers = HeaderUtil.createEntityUpdateAlert("myApp", true, "User","2");
+        assertEquals("myApp.User.updated", headers.getFirst("X-myApp-alert"));
+        assertEquals("2", headers.getFirst("X-myApp-params"));
+    }
+
+    @Test
+    public void createEntityUpdateAlertNoTranslation() {
+        HttpHeaders headers  = HeaderUtil.createEntityUpdateAlert("myApp", false, "User","2");
+        assertEquals("A User is updated with identifier 2", headers.getFirst("X-myApp-alert"));
+        assertEquals("2", headers.getFirst("X-myApp-params"));
+    }
+
+    @Test
+    public void createEntityDeletionAlertWithTranslation() {
+        HttpHeaders headers = HeaderUtil.createEntityDeletionAlert("myApp", true, "User","2");
+        assertEquals("myApp.User.deleted", headers.getFirst("X-myApp-alert"));
+        assertEquals("2", headers.getFirst("X-myApp-params"));
+    }
+    @Test
+    public void createEntityDeletionAlertNoTranslation() {
+        HttpHeaders headers = HeaderUtil.createEntityDeletionAlert("myApp", false, "User","2");
+        assertEquals("A User is deleted with identifier 2", headers.getFirst("X-myApp-alert"));
+        assertEquals("2", headers.getFirst("X-myApp-params"));
+    }
+
+    @Test
+    public void createFailureAlertWithTranslation() {
+        HttpHeaders headers = HeaderUtil.createFailureAlert("myApp", true, "User","404","Failed to find user");
+        assertEquals("error.404", headers.getFirst("X-myApp-error"));
+        assertEquals("User", headers.getFirst("X-myApp-params"));
+    }
+    @Test
+    public void createFailureAlertNoTranslation() {
+        HttpHeaders headers = HeaderUtil.createFailureAlert("myApp", false, "User","404","Failed to find user");
+        assertEquals("Failed to find user", headers.getFirst("X-myApp-error"));
+        assertEquals("User", headers.getFirst("X-myApp-params"));
+    }
+}


### PR DESCRIPTION
This PR is an attempt to fix problem described in https://github.com/jhipster/generator-jhipster/issues/9282 and contains the following fixes/changes

- Add parameter `enableTranslation` to  `HeadeUtil` methods in order to create the proper headers 
- Add unit tests for  `HeadeUtil`
- Also add config property `jhipster.clientApp.name` that will be used by applications in order to pass the correct app name to `HeaderUtil`.