### PR TITLE
Remove Last-Modified setting from the cache filter

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/web/filter/CachingHttpHeadersFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/web/filter/CachingHttpHeadersFilter.java
@@ -34,9 +34,6 @@ public class CachingHttpHeadersFilter implements Filter {
     public static final int DEFAULT_DAYS_TO_LIVE = 1461; // 4 years
     public static final long DEFAULT_SECONDS_TO_LIVE = TimeUnit.DAYS.toMillis(DEFAULT_DAYS_TO_LIVE);
 
-    // We consider the last modified date is the start up time of the server
-    public final static long LAST_MODIFIED = System.currentTimeMillis();
-
     private long cacheTimeToLive = DEFAULT_SECONDS_TO_LIVE;
 
     private JHipsterProperties jHipsterProperties;
@@ -66,9 +63,6 @@ public class CachingHttpHeadersFilter implements Filter {
 
         // Setting Expires header, for proxy caching
         httpResponse.setDateHeader("Expires", cacheTimeToLive + System.currentTimeMillis());
-
-        // Setting the Last-Modified header, for browser caching
-        httpResponse.setDateHeader("Last-Modified", LAST_MODIFIED);
 
         chain.doFilter(request, response);
     }

--- a/jhipster-framework/src/test/java/io/github/jhipster/web/filter/CachingHttpHeadersFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/web/filter/CachingHttpHeadersFilterTest.java
@@ -20,7 +20,6 @@
 package io.github.jhipster.web.filter;
 
 import static io.github.jhipster.web.filter.CachingHttpHeadersFilter.DEFAULT_DAYS_TO_LIVE;
-import static io.github.jhipster.web.filter.CachingHttpHeadersFilter.LAST_MODIFIED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -78,7 +77,6 @@ public class CachingHttpHeadersFilterTest {
         verify(response).setHeader("Pragma", "cache");
         verify(response).setDateHeader(eq("Expires"), anyLong());
         assertThat(response.getDateHeader("Expires")).isBetween(before + secsToLive, after + secsToLive);
-        verify(response).setDateHeader("Last-Modified", LAST_MODIFIED);
         assertThat(caught).isNull();
     }
 
@@ -104,7 +102,6 @@ public class CachingHttpHeadersFilterTest {
         verify(response).setHeader("Pragma", "cache");
         verify(response).setDateHeader(eq("Expires"), anyLong());
         assertThat(response.getDateHeader("Expires")).isBetween(before + secsToLive, after + secsToLive);
-        verify(response).setDateHeader("Last-Modified", LAST_MODIFIED);
         assertThat(caught).isNull();
     }
 }


### PR DESCRIPTION
as `ResourceHttpRequestHandler` already sets it with the modification timestamp of the file system