### PR TITLE
Setting up Jhipster for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,19 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+trigger:
+- master
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- script: echo Hello, world!
+  displayName: 'Run a one-line script'
+
+- script: |
+    echo Add other tasks to build, test, and deploy your project.
+    echo See https://aka.ms/yaml
+  displayName: 'Run a multi-line script'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,19 +1,157 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
+#
+# Copyright 2013-2019 the original author or authors from the JHipster project.
+#
+# This file is part of the JHipster project, see https://www.jhipster.tech/
+# for more information.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-trigger:
-- master
 
-pool:
-  vmImage: 'ubuntu-latest'
+jobs:
+  - job: Test
+    pool:
+      vmImage: 'Ubuntu 16.04'
+    variables:
+      JHI_PROFILE: dev
+      JHI_RUN_APP: 1
+      JHI_PROTRACTOR: 0
+      JHI_ENTITY: sql
+      # this version is used for testing with CICD
+      JHI_VERSION: 0.0.0-CICD
+      # if JHI_LIB_BRANCH value is release, use the release from Maven
+      JHI_LIB_REPO: https://github.com/jhipster/jhipster.git
+      JHI_LIB_BRANCH: master
+      # if JHI_GEN_BRANCH value is release, use the release from NPM
+      JHI_GEN_REPO: https://github.com/jhipster/generator-jhipster.git
+      JHI_GEN_BRANCH: master
+      # specific config
+      SPRING_OUTPUT_ANSI_ENABLED: ALWAYS
+      SPRING_JPA_SHOW_SQL: false
+      JHI_DISABLE_WEBPACK_LOGS: true
+      JHI_E2E_HEADLESS: true
+      JHI_SCRIPTS: $HOME/generator-jhipster/test-integration/scripts
+    
+    strategy:
+      matrix:
+        ngx-default:
+          JHI_APP: ngx-default
+          JHI_PROFILE: prod
+          JHI_PROTRACTOR: 1
+        ngx-psql-es-noi18n-mapsid:
+          JHI_APP: ngx-psql-es-noi18n-mapsid
+          JHI_PROFILE: prod
+          JHI_PROTRACTOR: 1
+        ngx-gradle-fr:
+          JHI_APP: ngx-gradle-fr
+          JHI_PROFILE: prod
+          JHI_PROTRACTOR: 1
+        ngx-mariadb-oauth2-sass-infinispan:
+          JHI_APP: ngx-mariadb-oauth2-sass-infinispan
+          JHI_PROTRACTOR: 1
+        ngx-h2mem-ws-nol2:
+          JHI_APP: ngx-h2mem-ws-nol2
+        ngx-mongodb-kafka-cucumber:
+          JHI_APP: ngx-mongodb-kafka-cucumber
+          JHI_ENTITY: mongodb
+        ngx-session-cassandra-fr:
+          JHI_APP: ngx-session-cassandra-fr
+          JHI_ENTITY: cassandra
+        ngx-couchbase:
+          JHI_APP: ngx-couchbase
+          JHI_ENTITY: couchbase
+        ms-ngx-gateway-eureka:
+          JHI_APP: ms-ngx-gateway-eureka
+        ms-ngx-gateway-consul:
+          JHI_APP: ms-ngx-gateway-consul
+        ms-ngx-gateway-uaa:
+          JHI_APP: ms-ngx-gateway-uaa
+          JHI_ENTITY: uaa
+        ms-micro-eureka:
+          JHI_APP: ms-micro-eureka
+          JHI_ENTITY: micro
+        ms-micro-consul:
+          JHI_APP: ms-micro-consul
+          JHI_ENTITY: micro
+        react-default:
+          JHI_APP: react-default
+    
+    steps:
+      - script: |
+          sudo /etc/init.d/mysql stop
+        displayName: 'Before Install'
+      #----------------------------------------------------------------------
+      # Install all tools and check configuration
+      #----------------------------------------------------------------------
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '10.15.3'
+        displayName: 'TOOLS: install Node.js'
+        
+      # Upgrade NPM
+      - script: npm install -g npm
+        displayName: 'TOOLS: update NPM'
 
-steps:
-- script: echo Hello, world!
-  displayName: 'Run a one-line script'
+      - script: |
+          set -e
+          sudo add-apt-repository ppa:openjdk-r/ppa
+          sudo apt-get update
+          sudo apt-get install -y openjdk-8-jdk
+          sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
+          java -version
+        displayName: 'TOOLS: configuring OpenJDK'
 
-- script: |
-    echo Add other tasks to build, test, and deploy your project.
-    echo See https://aka.ms/yaml
-  displayName: 'Run a multi-line script'
+      - script: |
+          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+          sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+          sudo apt update
+          sudo apt install google-chrome-stable
+        displayName: 'TOOLS: install google-chrome-stable'
+
+      - script: |
+          git config --global user.name "JHipster Bot"
+          git config --global user.email "jhipster-bot@jhipster.tech"
+        displayName: 'TOOLS: configure git'
+
+
+      #----------------------------------------------------------------------
+      # Install JHipster and generate project+entities
+      #----------------------------------------------------------------------
+      - bash: $(Build.Repository.LocalPath)/test-integration/scripts/10-install-jhipster-lib.sh
+        displayName: 'GENERATION: install JHipster library'
+      - bash: $(JHI_SCRIPTS)/11-generate-entities.sh
+        displayName: 'GENERATION: entities'
+      - bash: $(JHI_SCRIPTS)/12-generate-project.sh
+        displayName: 'GENERATION: project'
+      - bash: $(JHI_SCRIPTS)/13-replace-version-generated-project.sh
+        displayName: 'GENERATION: replace version in generated project'
+      - bash: $(JHI_SCRIPTS)/14-jhipster-info.sh
+        displayName: 'GENERATION: jhipster info'
+
+        
+      #----------------------------------------------------------------------
+      # Launch tests
+      #----------------------------------------------------------------------
+      - bash: $(JHI_SCRIPTS)/20-docker-compose.sh
+        displayName: 'TESTS: Start docker-compose containers'
+      - bash: $(JHI_SCRIPTS)/21-tests-backend.sh
+        displayName: 'TESTS: backend'
+      - bash: $(JHI_SCRIPTS)/22-tests-frontend.sh
+        displayName: 'TESTS: frontend'
+      - bash: $(JHI_SCRIPTS)/23-package.sh
+        displayName: 'TESTS: packaging'
+      - bash: $(JHI_SCRIPTS)/24-tests-e2e.sh
+        displayName: 'TESTS: End-to-End'
+      - bash: $(JHI_SCRIPTS)/25-sonar-analyze.sh
+        displayName: 'TESTS: Sonar analyze'
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,6 +90,8 @@ jobs:
       - script: |
           sudo /etc/init.d/mysql stop
         displayName: 'Before Install'
+
+
       #----------------------------------------------------------------------
       # Install all tools and check configuration
       #----------------------------------------------------------------------
@@ -98,7 +100,6 @@ jobs:
           versionSpec: '10.15.3'
         displayName: 'TOOLS: install Node.js'
         
-      # Upgrade NPM
       - script: npm install -g npm
         displayName: 'TOOLS: update NPM'
 


### PR DESCRIPTION
**Overview of the issue**

Since Travis future is now uncertain, we should progressively migrate our CI to Azure Pipelines like we did for the generator or prettier-java.

**Motivation for or Use Case**

Travis is not doing well.
Azure Pipelines can have up to 10 parallel jobs (5 for Travis)

I worked on the migration to Azure Pipelines and made it work. We just need to configure the repository on Azure.
You can checkout the builds [here](https://dev.azure.com/lingchun/jhipster/_build?definitionId=21)