### PR TITLE
Filters for new field types: Duration and UUID

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/DurationFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/DurationFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016-2019 the original author or authors.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jhipster.service.filter;
+
+import java.time.Duration;
+
+/**
+ * Filter class for {@link Duration} type attributes.
+ *
+ * @see Filter
+ */
+public class DurationFilter extends RangeFilter<Duration> {
+
+    private static final long serialVersionUID = 1L;
+
+    public DurationFilter() {
+    }
+
+    public DurationFilter(final DurationFilter filter) {
+        super(filter);
+    }
+
+    public DurationFilter copy() {
+        return new DurationFilter(this);
+    }
+
+}

--- a/jhipster-framework/src/main/java/io/github/jhipster/service/filter/UUIDFilter.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/service/filter/UUIDFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016-2019 the original author or authors.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jhipster.service.filter;
+
+import java.util.UUID;
+
+/**
+ * Filter class for {@link UUID} type attributes.
+ *
+ * @see Filter
+ */
+public class UUIDFilter extends Filter<UUID> {
+
+    private static final long serialVersionUID = 1L;
+
+    public UUIDFilter() {
+    }
+
+    public UUIDFilter(final UUIDFilter filter) {
+        super(filter);
+    }
+
+    public UUIDFilter copy() {
+        return new UUIDFilter(this);
+    }
+
+}

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/filter/DurationFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/filter/DurationFilterTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2016-2019 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jhipster.service.filter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DurationFilterTest {
+
+    private DurationFilter filter;
+
+    private Duration value = Duration.ofMinutes(5);
+
+    @BeforeEach
+    public void setup() {
+        filter = new DurationFilter();
+    }
+
+    @Test
+    public void testConstructor() {
+        assertThat(filter.getEquals()).isNull();
+        assertThat(filter.getGreaterThan()).isNull();
+        assertThat(filter.getGreaterOrEqualThan()).isNull();
+        assertThat(filter.getLessThan()).isNull();
+        assertThat(filter.getLessOrEqualThan()).isNull();
+        assertThat(filter.getSpecified()).isNull();
+        assertThat(filter.getIn()).isNull();
+        assertThat(filter.toString()).isEqualTo("DurationFilter []");
+    }
+
+    @Test
+    public void testSetEquals() {
+        Filter<Duration> chain = filter.setEquals(value);
+        assertThat(chain).isEqualTo(filter);
+        assertThat(filter.getEquals()).isEqualTo(value);
+    }
+
+    @Test
+    public void testSetLessThan() {
+        Filter<Duration> chain = filter.setLessThan(value);
+        assertThat(chain).isEqualTo(filter);
+        assertThat(filter.getLessThan()).isEqualTo(value);
+    }
+
+    @Test
+    public void testSetLessOrEqualThan() {
+        Filter<Duration> chain = filter.setLessOrEqualThan(value);
+        assertThat(chain).isEqualTo(filter);
+        assertThat(filter.getLessOrEqualThan()).isEqualTo(value);
+    }
+
+    @Test
+    public void testSetGreaterThan() {
+        Filter<Duration> chain = filter.setGreaterThan(value);
+        assertThat(chain).isEqualTo(filter);
+        assertThat(filter.getGreaterThan()).isEqualTo(value);
+    }
+
+    @Test
+    public void testSetGreaterOrEqualThan() {
+        Filter<Duration> chain = filter.setGreaterOrEqualThan(value);
+        assertThat(chain).isEqualTo(filter);
+        assertThat(filter.getGreaterOrEqualThan()).isEqualTo(value);
+    }
+
+    @Test
+    public void testSetSpecified() {
+        Filter<Duration> chain = filter.setSpecified(true);
+        assertThat(chain).isEqualTo(filter);
+        assertThat(filter.getSpecified()).isEqualTo(true);
+    }
+
+    @Test
+    public void testSetIn() {
+        List<Duration> list = new LinkedList<>();
+        Filter<Duration> chain = filter.setIn(list);
+        assertThat(chain).isEqualTo(filter);
+        assertThat(filter.getIn()).isEqualTo(list);
+    }
+
+    @Test
+    public void testToString() {
+        filter.setEquals(value);
+        filter.setLessThan(value);
+        filter.setLessOrEqualThan(value);
+        filter.setGreaterThan(value);
+        filter.setGreaterOrEqualThan(value);
+        filter.setSpecified(true);
+        filter.setIn(new LinkedList<>());
+        String str = value.toString();
+        assertThat(filter.toString()).isEqualTo("DurationFilter "
+            + "[greaterThan=" + str + ", greaterOrEqualThan=" + str + ", lessThan=" + str + ", "
+            + "lessOrEqualThan=" + str + ", equals=" + str + ", specified=true, in=[]]");
+    }
+}

--- a/jhipster-framework/src/test/java/io/github/jhipster/service/filter/UUIDFilterTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/service/filter/UUIDFilterTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016-2019 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jhipster.service.filter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UUIDFilterTest {
+
+    private UUIDFilter filter;
+
+    private UUID value = UUID.fromString("dbc36987-d354-4ddf-9b53-38ca19b5a409");
+
+    @BeforeEach
+    public void setup() {
+        filter = new UUIDFilter();
+    }
+
+    @Test
+    public void testConstructor() {
+        assertThat(filter.getEquals()).isNull();
+        assertThat(filter.getSpecified()).isNull();
+        assertThat(filter.getIn()).isNull();
+        assertThat(filter.toString()).isEqualTo("UUIDFilter []");
+    }
+
+    @Test
+    public void testSetEquals() {
+        Filter<UUID> chain = filter.setEquals(value);
+        assertThat(chain).isEqualTo(filter);
+        assertThat(filter.getEquals()).isEqualTo(value);
+    }
+
+    @Test
+    public void testSetSpecified() {
+        Filter<UUID> chain = filter.setSpecified(true);
+        assertThat(chain).isEqualTo(filter);
+        assertThat(filter.getSpecified()).isEqualTo(true);
+    }
+
+    @Test
+    public void testSetIn() {
+        List<UUID> list = new LinkedList<>();
+        Filter<UUID> chain = filter.setIn(list);
+        assertThat(chain).isEqualTo(filter);
+        assertThat(filter.getIn()).isEqualTo(list);
+    }
+
+    @Test
+    public void testToString() {
+        filter.setEquals(value);
+        filter.setSpecified(true);
+        filter.setIn(new LinkedList<>());
+        assertThat(filter.toString()).isEqualTo("UUIDFilter [equals=dbc36987-d354-4ddf-9b53-38ca19b5a409, in=[], specified=true]");
+    }
+}


### PR DESCRIPTION
DurationFilter is created in each generated project, it should be in the framework: https://github.com/jhipster/generator-jhipster/blob/6460e91e482321a916fbc934342481817fe5ed2b/generators/entity-server/templates/src/main/java/package/service/dto/EntityCriteria.java.ejs#L58 and https://github.com/jhipster/generator-jhipster/blob/6460e91e482321a916fbc934342481817fe5ed2b/generators/entity-server/templates/src/main/java/package/service/dto/EntityCriteria.java.ejs#L82

UUIDFilter is required for https://github.com/jhipster/generator-jhipster/issues/9793