### PR TITLE
Convert Duration to nanoseconds, rather than milliseconds

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/domain/util/JSR310DateConverters.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/domain/util/JSR310DateConverters.java
@@ -117,7 +117,7 @@ public final class JSR310DateConverters {
 
         @Override
         public Long convert(Duration source) {
-            return source == null ? null : source.toMillis();
+            return source == null ? null : source.toNanos();
         }
     }
 
@@ -130,7 +130,7 @@ public final class JSR310DateConverters {
 
         @Override
         public Duration convert(Long source) {
-            return source == null ? null : Duration.ofMillis(source);
+            return source == null ? null : Duration.ofNanos(source);
         }
     }
 }


### PR DESCRIPTION
It's more accurate, and is consistent with what Hibernate does: [DurationType.java](https://github.com/hibernate/hibernate-orm/blob/e5dc635a52362f69b69acb8d5b166b69b165dbbd/hibernate-core/src/main/java/org/hibernate/type/DurationType.java#L32)

If we don't handle/serialize the same way a Duration in Mongo or in a SQL Database, this can be very confusing for our users