### PR TITLE
typo in a comment about JWT

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterDefaults.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterDefaults.java
@@ -120,8 +120,8 @@ public interface JHipsterDefaults {
 
                 String secret = null;
                 String base64Secret = null;
-                long tokenValidityInSeconds = 1800; // 0.5 hour
-                long tokenValidityInSecondsForRememberMe = 2592000; // 30 hours;
+                long tokenValidityInSeconds = 1800; // 30 minutes
+                long tokenValidityInSecondsForRememberMe = 2592000; // 30 days
             }
         }
 
@@ -172,7 +172,7 @@ public interface JHipsterDefaults {
     interface Logging {
 
         boolean useJsonFormat = false;
-        
+
         interface Logstash {
 
             boolean enabled = false;


### PR DESCRIPTION
In the comment about JWT, there was an error of conversion between seconds and days. 

@jdubois 

On this subject of authentication

Maybe it could be cool to declare `tokenValidityInSecondsForRememberMe` and `tokenValidityInSeconds` in `application.yml` . In fact, validity period is very important for an application in terms of security. Let the developer the possibility to easy customize it in `application.yml` could maybe be a good idea. 

Furthermore, at https://github.com/jhipster/generator-jhipster/blob/229ed340f7958af1ea3bcac5eea6c4aab839a835/generators/server/templates/src/main/java/package/security/jwt/TokenProvider.java.ejs#L92 it could be cool to `log.info` about tokens generated (login of the user and validity period). 

If you think that the idea it interesting I could make the PR. 

