### PR TITLE
Update testcontainers to latest: version 1.12.4

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -80,7 +80,7 @@
         <spring-security-jwt.version>1.1.0.RELEASE</spring-security-jwt.version>
         <spring-security-oauth.version>2.4.0.RELEASE</spring-security-oauth.version>
         <springfox.version>2.9.2</springfox.version>
-        <testcontainers.version>1.12.3</testcontainers.version>
+        <testcontainers.version>1.12.4</testcontainers.version>
         <xmemcached.version>2.4.6</xmemcached.version>
         <xmemcached-provider.version>4.1.3</xmemcached-provider.version>
     </properties>


### PR DESCRIPTION
There's a new patch version of testcontainers; version 1.12.4 which has some improvements for https://github.com/testcontainers/testcontainers-java/issues/1453 which hopefully improves on the intermittent failures in the couch-base module (https://github.com/jhipster/generator-jhipster/issues/10594). 😄 