### PR TITLE
Throw ResponseStatusException in wrapOrNotFound

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/web/util/ResponseUtil.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/web/util/ResponseUtil.java
@@ -22,6 +22,7 @@ package io.github.jhipster.web.util;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
 
@@ -44,15 +45,16 @@ public interface ResponseUtil {
 
     /**
      * Wrap the optional into a {@link org.springframework.http.ResponseEntity} with an {@link org.springframework.http.HttpStatus#OK} status with the headers, or if it's
-     * empty, it returns a {@link org.springframework.http.ResponseEntity} with {@link org.springframework.http.HttpStatus#NOT_FOUND}.
+     * empty, throws a {@link org.springframework.web.server.ResponseStatusException} with status {@link org.springframework.http.HttpStatus#NOT_FOUND}.
      *
      * @param <X>           type of the response
      * @param maybeResponse response to return if present
      * @param header        headers to be added to the response
-     * @return response containing {@code maybeResponse} if present or {@link org.springframework.http.HttpStatus#NOT_FOUND}
+     * @return response containing {@code maybeResponse} if present
+     * @throws ResponseStatusException {@code 404 (Not found)} if {@code maybeResponse} is empty
      */
     static <X> ResponseEntity<X> wrapOrNotFound(Optional<X> maybeResponse, HttpHeaders header) {
         return maybeResponse.map(response -> ResponseEntity.ok().headers(header).body(response))
-            .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 }

--- a/jhipster-framework/src/test/java/io/github/jhipster/web/util/ResponseUtilTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/web/util/ResponseUtilTest.java
@@ -24,10 +24,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 public class ResponseUtilTest {
 
@@ -56,10 +57,7 @@ public class ResponseUtilTest {
 
     @Test
     public void testNoWithoutHeaders() {
-        ResponseEntity<Integer> response = ResponseUtil.wrapOrNotFound(no);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
-        assertThat(response.getBody()).isNull();
-        assertThat(response.getHeaders()).isEmpty();
+        assertThatExceptionOfType(ResponseStatusException.class).isThrownBy(() -> ResponseUtil.wrapOrNotFound(no));
     }
 
     @Test
@@ -74,9 +72,6 @@ public class ResponseUtilTest {
 
     @Test
     public void testNoWithHeaders() {
-        ResponseEntity<Integer> response = ResponseUtil.wrapOrNotFound(no, headers);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
-        assertThat(response.getBody()).isNull();
-        assertThat(response.getHeaders()).isEmpty();
+        assertThatExceptionOfType(ResponseStatusException.class).isThrownBy(() -> ResponseUtil.wrapOrNotFound(no, headers));
     }
 }


### PR DESCRIPTION
The ExceptionTranslator will translate the exception to 404 and set the Problem details appropriately.