### PR TITLE
Allow any characters in notification parameter

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/web/util/HeaderUtil.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/web/util/HeaderUtil.java
@@ -4,6 +4,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 /**
  * Utility class for HTTP headers creation.
  */
@@ -25,7 +29,11 @@ public final class HeaderUtil {
     public static HttpHeaders createAlert(String applicationName, String message, String param) {
         HttpHeaders headers = new HttpHeaders();
         headers.add("X-" + applicationName + "-alert", message);
-        headers.add("X-" + applicationName + "-params", param);
+        try {
+            headers.add("X-" + applicationName + "-params", URLEncoder.encode(param, StandardCharsets.UTF_8.toString()));
+        } catch (UnsupportedEncodingException e) {
+            // StandardCharsets are supported by every Java implementation so this exception will never happen
+        }
         return headers;
     }
 


### PR DESCRIPTION
This is the first part for the jhipster/generator-jhipster#10877

This alert parameter is used:
* in Angular user management and entities
* in React user management and entities
* in Vue.js user management only (in entities instead of using HTTP header returned from JHipster server side library, this parameter is used from data already available in client application)

Currently in symbols used by entity `id` or user `login`, symbol @ causes incompatibility between old and new version, because `@` is encoded to `%40`.

So to avoid showing `@` as `%40` in default generated projects, blueprints should adapt this change.

I'll do PR for Angular and React in the `generator-jhipster` and in `vue.js` blueprint to adapt this change there.