### PR TITLE
Build instructions for Windows to skip signing artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project is used by the JHipster generator. This is the Bill of Materials an
 
 If the current version is SNAPSHOT then to use this SNAPSHOT version:
 - clone this project
-- run `mvnw clean install -Dgpg.skip=true`
+- run `./mvnw clean install -Dgpg.skip=true`, on Windows run `.\mvnw.cmd clean install -D"gpg.skip=true"`
 
 [travis-image]: https://travis-ci.org/jhipster/jhipster.svg?branch=master
 [travis-url]: https://travis-ci.org/jhipster/jhipster


### PR DESCRIPTION
In Windows Powershell, running `.\mvnw.cmd clean install -Dgpg.skip=true`  fails as:

> [ERROR] Unknown lifecycle phase ".skip=true". You must specify a valid lifecycle phase or a goal in the format

The correct way is to use quotes  `.\mvnw.cmd clean install -D"gpg.skip=true"` 