### PR TITLE
Use Oracle Database Client libraries from Maven Central

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -286,7 +286,7 @@
                 <version>${mssql-jdbc.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.oracle.ojdbc</groupId>
+                <groupId>com.oracle.database.jdbc</groupId>
                 <artifactId>ojdbc8</artifactId>
                 <version>${oracle-jdbc.version}</version>
             </dependency>


### PR DESCRIPTION
If the JHipster team feels this is something worth switching to; I can make the required changes.

**Reference**: https://blogs.oracle.com/developers/oracle-database-client-libraries-for-java-now-on-maven-central
