### PR TITLE
Custom cache key generator

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/config/cache/PrefixedKeyGenerator.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/cache/PrefixedKeyGenerator.java
@@ -1,0 +1,36 @@
+package io.github.jhipster.config.cache;
+
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.info.GitProperties;
+import org.springframework.cache.interceptor.KeyGenerator;
+
+import java.lang.reflect.Method;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+public class PrefixedKeyGenerator implements KeyGenerator {
+
+    private final String prefix;
+
+    public PrefixedKeyGenerator(GitProperties gitProperties, BuildProperties buildProperties) {
+
+        String shortCommitId = gitProperties.getShortCommitId();
+        Instant time = buildProperties.getTime();
+        String version = buildProperties.getVersion();
+        Object prefixObject = ObjectUtils.firstNonNull(shortCommitId, time, version, RandomStringUtils.randomAlphanumeric(12));
+
+        if (prefixObject instanceof  Instant) {
+            this.prefix = DateTimeFormatter.ISO_INSTANT.format((Instant) prefixObject);
+        } else {
+            this.prefix = prefixObject.toString();
+        }
+    }
+
+
+    @Override
+    public Object generate(Object target, Method method, Object... params) {
+        return new PrefixedSimpleKey(prefix, method.getName(), params);
+    }
+}

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/cache/PrefixedKeyGenerator.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/cache/PrefixedKeyGenerator.java
@@ -20,6 +20,10 @@ public class PrefixedKeyGenerator implements KeyGenerator {
         this.prefix = generatePrefix(gitProperties, buildProperties);
     }
 
+    String getPrefix() {
+        return this.prefix;
+    }
+
     private String generatePrefix(GitProperties gitProperties, BuildProperties buildProperties) {
 
         String shortCommitId = null;

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/cache/PrefixedKeyGenerator.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/cache/PrefixedKeyGenerator.java
@@ -9,6 +9,7 @@ import org.springframework.cache.interceptor.KeyGenerator;
 import java.lang.reflect.Method;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Objects;
 
 public class PrefixedKeyGenerator implements KeyGenerator {
 
@@ -16,16 +17,28 @@ public class PrefixedKeyGenerator implements KeyGenerator {
 
     public PrefixedKeyGenerator(GitProperties gitProperties, BuildProperties buildProperties) {
 
-        String shortCommitId = gitProperties.getShortCommitId();
-        Instant time = buildProperties.getTime();
-        String version = buildProperties.getVersion();
-        Object prefixObject = ObjectUtils.firstNonNull(shortCommitId, time, version, RandomStringUtils.randomAlphanumeric(12));
+        this.prefix = generatePrefix(gitProperties, buildProperties);
+    }
 
-        if (prefixObject instanceof  Instant) {
-            this.prefix = DateTimeFormatter.ISO_INSTANT.format((Instant) prefixObject);
-        } else {
-            this.prefix = prefixObject.toString();
+    private String generatePrefix(GitProperties gitProperties, BuildProperties buildProperties) {
+
+        String shortCommitId = null;
+        if (Objects.nonNull(gitProperties)) {
+            shortCommitId = gitProperties.getShortCommitId();
         }
+
+        Instant time = null;
+        String version = null;
+        if (Objects.nonNull(buildProperties)) {
+            time = buildProperties.getTime();
+            version = buildProperties.getVersion();
+        }
+        Object p = ObjectUtils.firstNonNull(shortCommitId, time, version, RandomStringUtils.randomAlphanumeric(12));
+
+        if (p instanceof Instant) {
+            return DateTimeFormatter.ISO_INSTANT.format((Instant) p);
+        }
+        return p.toString();
     }
 
 

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/cache/PrefixedSimpleKey.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/cache/PrefixedSimpleKey.java
@@ -1,0 +1,45 @@
+package io.github.jhipster.config.cache;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+public class PrefixedSimpleKey implements Serializable {
+
+    private final String prefix;
+    private final Object[] params;
+    private final String methodName;
+    private int hashCode;
+
+    public PrefixedSimpleKey(String prefix, String methodName, Object... elements) {
+        Assert.notNull(prefix, "Prefix must not be null");
+        Assert.notNull(elements, "Elements must not be null");
+        this.prefix = prefix;
+        this.methodName = methodName;
+        this.params = new Object[elements.length];
+        System.arraycopy(elements, 0, this.params, 0, elements.length);
+        this.hashCode = prefix.hashCode();
+        this.hashCode = 31 * this.hashCode + methodName.hashCode();
+        this.hashCode = 31 * this.hashCode + Arrays.deepHashCode(this.params);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return (this == other ||
+            (other instanceof PrefixedSimpleKey && this.prefix.equals(((PrefixedSimpleKey) other).prefix) &&
+                this.methodName.equals(((PrefixedSimpleKey) other).methodName) &&
+                Arrays.deepEquals(this.params, ((PrefixedSimpleKey) other).params)));
+    }
+
+    @Override
+    public final int hashCode() {
+        return this.hashCode;
+    }
+
+    @Override
+    public String toString() {
+        return this.prefix + " " + getClass().getSimpleName() + this.methodName + " [" + StringUtils.arrayToCommaDelimitedString(this.params) + "]";
+    }
+}

--- a/jhipster-framework/src/test/java/io/github/jhipster/config/cache/PrefixedKeyGeneratorTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/config/cache/PrefixedKeyGeneratorTest.java
@@ -1,0 +1,65 @@
+package io.github.jhipster.config.cache;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.info.GitProperties;
+
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PrefixedKeyGeneratorTest {
+
+    @Test
+    public void generatePrefixFromShortCommitId() {
+
+        Properties gitProperties = new Properties();
+        gitProperties.put("commit.id.abbrev", "1234");
+
+        PrefixedKeyGenerator prefixedKeyGenerator = new PrefixedKeyGenerator(new GitProperties(gitProperties), null);
+
+        assertThat(prefixedKeyGenerator.getPrefix()).isEqualTo("1234");
+    }
+
+    @Test
+    public void generatePrefixFromCommitId() {
+
+        Properties gitProperties = new Properties();
+        gitProperties.put("commit.id", "1234567");
+
+        PrefixedKeyGenerator prefixedKeyGenerator = new PrefixedKeyGenerator(new GitProperties(gitProperties), null);
+
+        assertThat(prefixedKeyGenerator.getPrefix()).isEqualTo("1234567");
+    }
+
+    @Test
+    public void generatePrefixFromBuildVersion() {
+
+        Properties buildProperties = new Properties();
+        buildProperties.put("version", "1.0.0");
+
+        PrefixedKeyGenerator prefixedKeyGenerator = new PrefixedKeyGenerator(null, new BuildProperties(buildProperties));
+
+        assertThat(prefixedKeyGenerator.getPrefix()).isEqualTo("1.0.0");
+    }
+
+    @Test
+    public void generatePrefixFromBuildTime() {
+
+        Properties buildProperties = new Properties();
+        buildProperties.put("time", "1583955265");
+
+        PrefixedKeyGenerator prefixedKeyGenerator = new PrefixedKeyGenerator(null, new BuildProperties(buildProperties));
+
+        assertThat(prefixedKeyGenerator.getPrefix()).isEqualTo("1970-01-19T07:59:15.265Z");
+    }
+
+    @Test
+    public void generatesRandomPrefix() {
+
+        PrefixedKeyGenerator prefixedKeyGenerator = new PrefixedKeyGenerator(null, null);
+
+        assertThat(prefixedKeyGenerator.getPrefix().length()).isEqualTo(12);
+    }
+
+}

--- a/jhipster-framework/src/test/java/io/github/jhipster/config/cache/PrefixedSimpleKeyTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/config/cache/PrefixedSimpleKeyTest.java
@@ -1,0 +1,48 @@
+package io.github.jhipster.config.cache;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class PrefixedSimpleKeyTest {
+
+    @Test
+    public void sameMethodSamePrefixSameParametersShouldBeSame() {
+
+        PrefixedSimpleKey prefixedSimpleKey = new PrefixedSimpleKey("prefix", "setX", "x", "y");
+        PrefixedSimpleKey prefixedSimpleKey2 = new PrefixedSimpleKey("prefix", "setX", "x", "y");
+
+        Assertions.assertThat(prefixedSimpleKey).isEqualTo(prefixedSimpleKey2);
+        Assertions.assertThat(prefixedSimpleKey.hashCode()).isEqualTo(prefixedSimpleKey2.hashCode());
+    }
+
+    @Test
+    public void sameMethodSamePrefixSameParameterShouldBeSame() {
+
+        PrefixedSimpleKey prefixedSimpleKey = new PrefixedSimpleKey("prefix", "setX", "x");
+        PrefixedSimpleKey prefixedSimpleKey2 = new PrefixedSimpleKey("prefix", "setX", "x");
+
+        Assertions.assertThat(prefixedSimpleKey).isEqualTo(prefixedSimpleKey2);
+        Assertions.assertThat(prefixedSimpleKey.hashCode()).isEqualTo(prefixedSimpleKey2.hashCode());
+    }
+
+    @Test
+    public void sameMethodDifferentPrefixShouldBeDifferent() {
+
+        PrefixedSimpleKey prefixedSimpleKey = new PrefixedSimpleKey("prefix", "setX", "x");
+        PrefixedSimpleKey prefixedSimpleKey2 = new PrefixedSimpleKey("prefix2", "setX", "x");
+
+        Assertions.assertThat(prefixedSimpleKey).isNotEqualTo(prefixedSimpleKey2);
+        Assertions.assertThat(prefixedSimpleKey.hashCode()).isNotEqualTo(prefixedSimpleKey2.hashCode());
+    }
+
+    @Test
+    public void sameMethodDifferentParametersShouldBeDifferent() {
+
+        PrefixedSimpleKey prefixedSimpleKey = new PrefixedSimpleKey("prefix", "setX", "x");
+        PrefixedSimpleKey prefixedSimpleKey2 = new PrefixedSimpleKey("prefix", "setX", "y");
+
+        Assertions.assertThat(prefixedSimpleKey).isNotEqualTo(prefixedSimpleKey2);
+        Assertions.assertThat(prefixedSimpleKey.hashCode()).isNotEqualTo(prefixedSimpleKey2.hashCode());
+    }
+
+}


### PR DESCRIPTION
This provides a custom key generator which uses git and build properties to create a version specific cache key, such that changed objects are not loaded from cache. The integration in the main generator can be done after this is merged. This can basically done by providing a `Bean` of type `KeyGenerator` which creates a `PrefixedKeyGenerator`.

See https://github.com/jhipster/generator-jhipster/issues/9822 for details and [an example here ](https://github.com/atomfrede/jhipster-9822-redis-sample/blob/master/src/main/java/com/mycompany/myapp/config/CacheConfiguration.java)(all implemented in the application itself)