### PR TITLE
Restore sonar coverage reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
         <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
 
         <!-- Sonar properties -->
-        <sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
         <junit.utReportFolder>${project.testresult.directory}/test</junit.utReportFolder>
         <junit.itReportFolder>${project.testresult.directory}/integrationTest</junit.itReportFolder>
     </properties>
@@ -158,6 +157,7 @@
                         </execution>
                         <execution>
                             <id>default-report</id>
+                            <phase>test</phase>
                             <goals>
                                 <goal>report</goal>
                             </goals>
@@ -180,22 +180,6 @@
                                         </limits>
                                     </rule>
                                 </rules>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>merge</id>
-                            <goals>
-                                <goal>merge</goal>
-                            </goals>
-                            <configuration>
-                                <fileSets>
-                                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
-                                        <directory>${project.basedir}</directory>
-                                        <includes>
-                                            <include>**/jacoco.exec</include>
-                                        </includes>
-                                    </fileSet>
-                                </fileSets>
                             </configuration>
                         </execution>
                     </executions>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,8 +9,7 @@ sonar.sources=src/main/
 sonar.sourceEncoding=UTF-8
 
 sonar.tests=src/test/
-sonar.coverage.jacoco.xmlReportPaths=target/jacoco/test/jacoco.xml,target/jacoco/integrationTest/jacoco.xml
+sonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
 sonar.java.codeCoveragePlugin=jacoco
-sonar.junit.reportPaths=target/test-results/test,target/test-results/integrationTest
 
 sonar.exclusions=


### PR DESCRIPTION
I realized the problem was the deprecated `sonar.junit.reportPaths` property. I noticed this by running my own local sonar server and noticing this alert in the UI.

![Screenshot from 2020-03-23 12-30-38](https://user-images.githubusercontent.com/513471/77313297-dd19b380-6d03-11ea-8c2a-c8b5392d2b87.png)
