### PR TITLE
Publish artifacts to GitHub Packages

### DIFF
--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -1,0 +1,36 @@
+#
+# Copyright 2016-2020 the original author or authors from the JHipster project.
+#
+# This file is part of the JHipster project, see https://www.jhipster.tech/
+# for more information.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: GitHub Packages
+on:
+    push:
+        branches:
+            - master
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-java@v1
+              with:
+                  java-version: 1.8
+            - name: Publish package
+              # Sources and javadoc artifacts are not generated since GitHub Packages doesn't support multiple artifacts for snapshots
+              run: mvn deploy -Pdeploy-github -ntp -B -Dgpg.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -29,6 +29,12 @@ jobs:
             - uses: actions/setup-java@v1
               with:
                   java-version: 1.8
+            - name: Cache Maven packages
+              uses: actions/cache@v1
+              with:
+                  path: ~/.m2/repository
+                  key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+                  restore-keys: ${{ runner.os }}-m2
             - name: Publish package
               # Sources and javadoc artifacts are not generated since GitHub Packages doesn't support multiple artifacts for snapshots
               run: mvn deploy -Pdeploy-github -ntp -B -Dgpg.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -37,9 +37,8 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Test with Maven
         run: mvn test --batch-mode
       - name: Run Sonar analysis

--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -774,17 +774,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,23 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <!-- Deployment to GitHub Packages -->
+            <id>deploy-github</id>
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>github</id>
+                    <name>GitHub Packages</name>
+                    <url>https://maven.pkg.github.com/jhipster/jhipster</url>
+                    <uniqueVersion>true</uniqueVersion>
+                </snapshotRepository>
+                <repository>
+                    <id>github-releases</id>
+                    <name>GitHub Packages</name>
+                    <url>https://maven.pkg.github.com/jhipster/jhipster</url>
+                </repository>
+            </distributionManagement>
+        </profile>
     </profiles>
 
     <build>


### PR DESCRIPTION
New workflow that publishes all push to master to Github Packages.

I had to disable the generation and deployment of javadoc and sources since it's currently not supported by GitHub Packages (it generates an http 400 error when you then try retrieve metadata).