### PR TITLE
Upgrade couchbase-client to 2.7.14

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -47,7 +47,7 @@
         <cassandra-unit-spring.version>2.2.2.1</cassandra-unit-spring.version>
         <couchmove.version>2.0</couchmove.version>
         <!-- waiting for https://github.com/jhipster/generator-jhipster/issues/11491 -->
-        <couchbase-client.version>2.7.13</couchbase-client.version>
+        <couchbase-client.version>2.7.14</couchbase-client.version>
         <couchbase-encryption.version>2.0.1</couchbase-encryption.version>
         <!-- waiting for https://github.com/jhipster/generator-jhipster/issues/11136 -->
         <cucumber-jvm.version>4.8.1</cucumber-jvm.version>


### PR DESCRIPTION
Upgrade couchbase client to latest version 2. We can't actually use version 3 since it is not compatible yet with Spring Data Couchbase, it seems that it is planned for [4.0 RC2](https://jira.spring.io/browse/DATACOUCH-522?jql=project%20%3D%20DATACOUCH%20AND%20fixVersion%20%3D%20%224.0%20RC2%20(Neumann)%22) (see [DATACOUCH-517](https://jira.spring.io/browse/DATACOUCH-517))