### PR TITLE
add more memcache and redis properties

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterDefaults.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterDefaults.java
@@ -101,12 +101,20 @@ public interface JHipsterDefaults {
             String servers = "localhost:11211";
             int expiration = 300; // 5 minutes
             boolean useBinaryProtocol = true;
+
+            interface Authentication {
+                boolean enabled = false;
+            }
         }
 
         interface Redis {
             String[] server = {"redis://localhost:6379"};
             int expiration = 300; // 5 minutes
             boolean cluster = false;
+            int connectionPoolSize = 64; // default as in redisson
+            int connectionMinimumIdleSize = 24; // default as in redisson
+            int subscriptionConnectionPoolSize = 50; // default as in redisson
+            int subscriptionConnectionMinimumIdleSize = 1; // default as in redisson
         }
     }
 

--- a/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterProperties.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterProperties.java
@@ -535,6 +535,8 @@ public class JHipsterProperties {
 
             private boolean useBinaryProtocol = JHipsterDefaults.Cache.Memcached.useBinaryProtocol;
 
+            private Authentication authentication = new Authentication();
+
             public boolean isEnabled() {
                 return enabled;
             }
@@ -566,12 +568,54 @@ public class JHipsterProperties {
             public void setUseBinaryProtocol(boolean useBinaryProtocol) {
                 this.useBinaryProtocol = useBinaryProtocol;
             }
+
+            public Authentication getAuthentication() {
+                return authentication;
+            }
+
+            public static class Authentication {
+
+                private boolean enabled = JHipsterDefaults.Cache.Memcached.Authentication.enabled;
+                private String username;
+                private String password;
+
+                public boolean isEnabled() {
+                    return enabled;
+                }
+
+                public Authentication setEnabled(boolean enabled) {
+                    this.enabled = enabled;
+                    return this;
+                }
+
+                public String getUsername() {
+                    return username;
+                }
+
+                public Authentication setUsername(String username) {
+                    this.username = username;
+                    return this;
+                }
+
+                public String getPassword() {
+                    return password;
+                }
+
+                public Authentication setPassword(String password) {
+                    this.password = password;
+                    return this;
+                }
+            }
         }
 
         public static class Redis {
             private String[] server = JHipsterDefaults.Cache.Redis.server;
             private int expiration = JHipsterDefaults.Cache.Redis.expiration;
             private boolean cluster = JHipsterDefaults.Cache.Redis.cluster;
+            private int connectionPoolSize = JHipsterDefaults.Cache.Redis.connectionPoolSize;
+            private int connectionMinimumIdleSize = JHipsterDefaults.Cache.Redis.connectionMinimumIdleSize;
+            private int subscriptionConnectionPoolSize = JHipsterDefaults.Cache.Redis.subscriptionConnectionPoolSize;
+            private int subscriptionConnectionMinimumIdleSize = JHipsterDefaults.Cache.Redis.subscriptionConnectionMinimumIdleSize;
 
             public String[] getServer() {
                 return server;
@@ -595,6 +639,42 @@ public class JHipsterProperties {
 
             public void setCluster(boolean cluster) {
                 this.cluster = cluster;
+            }
+
+            public int getConnectionPoolSize() {
+                return connectionPoolSize;
+            }
+
+            public Redis setConnectionPoolSize(int connectionPoolSize) {
+                this.connectionPoolSize = connectionPoolSize;
+                return this;
+            }
+
+            public int getConnectionMinimumIdleSize() {
+                return connectionMinimumIdleSize;
+            }
+
+            public Redis setConnectionMinimumIdleSize(int connectionMinimumIdleSize) {
+                this.connectionMinimumIdleSize = connectionMinimumIdleSize;
+                return this;
+            }
+
+            public int getSubscriptionConnectionPoolSize() {
+                return subscriptionConnectionPoolSize;
+            }
+
+            public Redis setSubscriptionConnectionPoolSize(int subscriptionConnectionPoolSize) {
+                this.subscriptionConnectionPoolSize = subscriptionConnectionPoolSize;
+                return this;
+            }
+
+            public int getSubscriptionConnectionMinimumIdleSize() {
+                return subscriptionConnectionMinimumIdleSize;
+            }
+
+            public Redis setSubscriptionConnectionMinimumIdleSize(int subscriptionConnectionMinimumIdleSize) {
+                this.subscriptionConnectionMinimumIdleSize = subscriptionConnectionMinimumIdleSize;
+                return this;
             }
         }
     }

--- a/jhipster-framework/src/test/java/io/github/jhipster/config/JHipsterPropertiesTest.java
+++ b/jhipster-framework/src/test/java/io/github/jhipster/config/JHipsterPropertiesTest.java
@@ -329,6 +329,32 @@ public class JHipsterPropertiesTest {
     }
 
     @Test
+    public void testCacheMemcachedAuthenticationEnabled() {
+        JHipsterProperties.Cache.Memcached.Authentication obj = properties.getCache().getMemcached().getAuthentication();
+        boolean val = JHipsterDefaults.Cache.Memcached.Authentication.enabled;
+        assertThat(obj.isEnabled()).isEqualTo(val);
+        val = false;
+        obj.setEnabled(val);
+        assertThat(obj.isEnabled()).isEqualTo(val);
+    }
+
+    @Test
+    public void testCacheMemcachedAuthenticationPassword() {
+        JHipsterProperties.Cache.Memcached.Authentication obj = properties.getCache().getMemcached().getAuthentication();
+        assertThat(obj.getPassword()).isEqualTo(null);
+        obj.setPassword("MEMCACHEPASSWORD");
+        assertThat(obj.getPassword()).isEqualTo("MEMCACHEPASSWORD");
+    }
+
+    @Test
+    public void testCacheMemcachedAuthenticationUsername() {
+        JHipsterProperties.Cache.Memcached.Authentication obj = properties.getCache().getMemcached().getAuthentication();
+        assertThat(obj.getUsername()).isEqualTo(null);
+        obj.setUsername("MEMCACHEUSER");
+        assertThat(obj.getUsername()).isEqualTo("MEMCACHEUSER");
+    }
+
+    @Test
     public void testCacheRedisServer() {
         JHipsterProperties.Cache.Redis obj = properties.getCache().getRedis();
         String[] val = JHipsterDefaults.Cache.Redis.server;
@@ -356,6 +382,47 @@ public class JHipsterPropertiesTest {
         val = !val;
         obj.setCluster(val);
         assertThat(obj.isCluster()).isEqualTo(val);
+    }
+
+    @Test
+    public void testCacheRedisConnectionMinimumIdleSize() {
+        JHipsterProperties.Cache.Redis obj = properties.getCache().getRedis();
+        int val = JHipsterDefaults.Cache.Redis.connectionMinimumIdleSize;
+        assertThat(obj.getConnectionMinimumIdleSize()).isEqualTo(val);
+        val++;
+        obj.setConnectionMinimumIdleSize(val);
+        assertThat(obj.getConnectionMinimumIdleSize()).isEqualTo(val);
+    }
+
+    @Test
+    public void testCacheRedisConnectionPoolSize() {
+        JHipsterProperties.Cache.Redis obj = properties.getCache().getRedis();
+        int val = JHipsterDefaults.Cache.Redis.connectionPoolSize;
+        assertThat(obj.getConnectionPoolSize()).isEqualTo(val);
+        val++;
+        obj.setConnectionPoolSize(val);
+        assertThat(obj.getConnectionPoolSize()).isEqualTo(val);
+    }
+
+    @Test
+    public void testCacheRedisSubscriptionConnectionMinimumIdleSize() {
+        JHipsterProperties.Cache.Redis obj = properties.getCache().getRedis();
+        int val = JHipsterDefaults.Cache.Redis.subscriptionConnectionMinimumIdleSize;
+        assertThat(obj.getSubscriptionConnectionMinimumIdleSize()).isEqualTo(val);
+        val++;
+        obj.setSubscriptionConnectionMinimumIdleSize(val);
+        assertThat(obj.getSubscriptionConnectionMinimumIdleSize()).isEqualTo(val);
+    }
+
+    @Test
+    public void testCacheRedisSubscriptionConnectionPoolSize() {
+        JHipsterProperties.Cache.Redis obj = properties.getCache().getRedis();
+        int val = JHipsterDefaults.Cache.Redis.subscriptionConnectionPoolSize;
+        assertThat(obj.getSubscriptionConnectionPoolSize()).isEqualTo(val);
+        val++;
+        obj.setSubscriptionConnectionPoolSize(val);
+        assertThat(obj.getSubscriptionConnectionPoolSize()).isEqualTo(val);
+
     }
 
     @Test


### PR DESCRIPTION
to control e.g. connection limits easier in environments with limited resources

This introduces a few new properties to support more fine grained control for memcached and redis setup. This is particular interesting for deployment in cloud platforms with limited resources (e.g. heroku). When this is merged the [PR for redis and memcached support can be completed](https://github.com/jhipster/generator-jhipster/pull/11712).

updates https://github.com/jhipster/generator-jhipster/issues/11695
updates https://github.com/jhipster/generator-jhipster/issues/11696

EDIT: ~Still WIP as I need to check at my other machine if I miss some properties.~ Ready for review
