### PR TITLE
Add native dependabot support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+    - package-ecosystem: npm
+      directory: '/'
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 10


### PR DESCRIPTION
This adds native dependabot support for this project.

Related to https://github.com/jhipster/generator-jhipster/issues/11914