### PR TITLE
Fix Directories for jhipster-dependencies and jhipster-framework

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,15 @@
 version: 2
 updates:
-    - package-ecosystem: npm
-      directory: '/'
+    # Dependencies for jhipster-dependencies
+    - package-ecosystem: 'maven'
+      directory: '/jhipster-dependencies'
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 10
+
+    # Dependencies for jhipster-framework
+    - package-ecosystem: 'maven'
+      directory: '/jhipster-framework'
       schedule:
           interval: weekly
       open-pull-requests-limit: 10


### PR DESCRIPTION
This corrects a mistake in my [previous PR](https://github.com/jhipster/jhipster/pull/721) (I just copy and pasted it from jhipster-generator :blush:). We should point to the correct directories for dependabot to work correctly. 

Related to https://github.com/jhipster/generator-jhipster/issues/11914