### PR TITLE
make undertow configuration conditional on bean

### DIFF
--- a/jhipster-framework/src/main/java/io/github/jhipster/security/ssl/UndertowSSLConfiguration.java
+++ b/jhipster-framework/src/main/java/io/github/jhipster/security/ssl/UndertowSSLConfiguration.java
@@ -22,6 +22,7 @@ package io.github.jhipster.security.ssl;
 import io.undertow.UndertowOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory;
@@ -40,7 +41,8 @@ import org.springframework.context.annotation.Configuration;
  * @see <a href="https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices#25-use-forward-secrecy" target="_blank">More explanation on perfect forward secrecy</a>
  */
 @Configuration
-@ConditionalOnClass({UndertowServletWebServerFactory.class, UndertowOptions.class})
+@ConditionalOnBean(UndertowServletWebServerFactory.class)
+@ConditionalOnClass(UndertowOptions.class)
 @ConditionalOnProperty({"server.ssl.ciphers", "server.ssl.key-store"})
 public class UndertowSSLConfiguration {
 


### PR DESCRIPTION
This PR makes sure the `UndertowSSLConfiguration` is not enabled when using reactive option. From what I can tell, the netty ssl handler already honors the cipher suite order in the configuration (at least there is no option to set that).

closes https://github.com/jhipster/generator-jhipster/issues/12138